### PR TITLE
Add class constant for kotlin class

### DIFF
--- a/retroguard/src/main/java/com/yworks/yguard/obf/classfile/AttrInfo.java
+++ b/retroguard/src/main/java/com/yworks/yguard/obf/classfile/AttrInfo.java
@@ -170,6 +170,9 @@ public class AttrInfo implements ClassConstants
             else if (ATTR_NestMembers.equals(attrName)) {
                 ai = new NestMembersAttrInfo(cf, attrNameIndex, attrLength);
             }
+            else if (ATTR_KotlinSourceDebugExtension.equals(attrName)) {
+                ai = new AttrInfo( cf, attrNameIndex, attrLength);
+            }
             else {
               if ( attrLength > 0 ) {
                 Logger.getInstance().warning( "Unrecognized attribute '" + attrName + "' in " + Conversion.toJavaClass( cf.getName() ) );

--- a/retroguard/src/main/java/com/yworks/yguard/obf/classfile/AttrInfo.java
+++ b/retroguard/src/main/java/com/yworks/yguard/obf/classfile/AttrInfo.java
@@ -170,7 +170,7 @@ public class AttrInfo implements ClassConstants
             else if (ATTR_NestMembers.equals(attrName)) {
                 ai = new NestMembersAttrInfo(cf, attrNameIndex, attrLength);
             }
-            else if (ATTR_KotlinSourceDebugExtension.equals(attrName)) {
+            else if (ATTR_SourceDebugExtension.equals(attrName)) {
                 ai = new AttrInfo( cf, attrNameIndex, attrLength);
             }
             else {

--- a/retroguard/src/main/java/com/yworks/yguard/obf/classfile/ClassConstants.java
+++ b/retroguard/src/main/java/com/yworks/yguard/obf/classfile/ClassConstants.java
@@ -123,7 +123,7 @@ public interface  ClassConstants
     public static final String ATTR_NestHost = "NestHost";
     public static final String ATTR_NestMembers = "NestMembers";
     // source debug for kotlin
-    public static final String ATTR_KotlinSourceDebugExtension = "SourceDebugExtension";
+    public static final String ATTR_SourceDebugExtension = "SourceDebugExtension";
 
     public static final int REF_getField                = 1;
     public static final int REF_getStatic               = 2;

--- a/retroguard/src/main/java/com/yworks/yguard/obf/classfile/ClassConstants.java
+++ b/retroguard/src/main/java/com/yworks/yguard/obf/classfile/ClassConstants.java
@@ -122,6 +122,8 @@ public interface  ClassConstants
     // new in java 11
     public static final String ATTR_NestHost = "NestHost";
     public static final String ATTR_NestMembers = "NestMembers";
+    // source debug for kotlin
+    public static final String ATTR_KotlinSourceDebugExtension = "SourceDebugExtension";
 
     public static final int REF_getField                = 1;
     public static final int REF_getStatic               = 2;


### PR DESCRIPTION
```SourceDebugExtension``` of kotlin class only have purpose for debugging.
It's not affected to process of yguard.
So I propose to add this attributes as recognized.