### PR TITLE
Fix $ sign problems

### DIFF
--- a/retroguard/src/main/java/com/yworks/yguard/obf/GuardDB.java
+++ b/retroguard/src/main/java/com/yworks/yguard/obf/GuardDB.java
@@ -414,7 +414,7 @@ public class GuardDB implements ClassConstants
               }
               else
               {
-                outName = classTree.getOutName(inName);
+                outName = inName;
               }
 
               if(resourceHandler == null || !resourceHandler.filterContent(inStream, dataOutputStream, inName))


### PR DESCRIPTION
This closes #17
If I understand correctly, the else clause is run when:

- the file is not a class file
- the file is not a metainfo file
- the file is not remapped by any rules (adjust sections)

Why do we need to run this at all? If I understand correctly, no checks are needed further. The faulty behaviour stems from executing `ClassTree.getOutName` which has an entirely different purpose, and for which the behaviour is incorrect.
Anything I am missing before merging this @thomasbehr ?
