### PR TITLE
Add fxml example

### DIFF
--- a/examples/fxml/build.gradle
+++ b/examples/fxml/build.gradle
@@ -1,0 +1,58 @@
+plugins {
+  // Apply the java and library plugin to add support for Java
+  id 'application'
+  id 'org.openjfx.javafxplugin' version '0.0.8'
+}
+
+application {
+  version = '11'
+  mainClassName = 'animations.Animations'
+}
+
+jar {
+  manifest {
+    attributes(
+      'Main-Class': application.mainClassName
+    )
+  }
+}
+
+javafx {
+  modules = [ 'javafx.controls', 'javafx.fxml' ]
+}
+
+repositories {
+  mavenLocal()
+  mavenCentral()
+}
+
+dependencies {
+  compile 'com.yworks:yguard:3.0.0-SNAPSHOT'
+}
+
+task obfuscate {
+  dependsOn jar
+  group 'yGuard'
+  description 'Obfuscates and shrinks the java archive.'
+
+  doLast {
+    ant.taskdef(
+            name: 'yguard',
+            classname: 'com.yworks.yguard.YGuardTask',
+            classpath: sourceSets.main.runtimeClasspath.asPath
+    )
+
+    def archivePath = jar.archiveFile.get().asFile.path
+    ant.yguard {
+      inoutpair(in: archivePath, out: archivePath.replace(".jar", "_obf.jar"))
+      shrink(logfile: "${buildDir}/yshrink.log.xml") {
+        keep {
+          method(name: "void main(java.lang.String[])", "class": application.mainClassName)
+        }
+      }
+      rename(mainclass: application.mainClassName, logfile: "${buildDir}/yguard.log.xml") {
+        property(name: "error-checking", value: "pedantic")
+      }
+    }
+  }
+}

--- a/examples/fxml/build.gradle
+++ b/examples/fxml/build.gradle
@@ -28,6 +28,7 @@ repositories {
 
 dependencies {
   compile 'com.yworks:yguard:3.0.0-SNAPSHOT'
+  compile 'com.yworks:annotation:3.0.0-SNAPSHOT'
 }
 
 task obfuscate {
@@ -45,13 +46,12 @@ task obfuscate {
     def archivePath = jar.archiveFile.get().asFile.path
     ant.yguard {
       inoutpair(in: archivePath, out: archivePath.replace(".jar", "_obf.jar"))
-      shrink(logfile: "${buildDir}/yshrink.log.xml") {
-        keep {
-          method(name: "void main(java.lang.String[])", "class": application.mainClassName)
-        }
-      }
       rename(mainclass: application.mainClassName, logfile: "${buildDir}/yguard.log.xml") {
         property(name: "error-checking", value: "pedantic")
+        keep {
+          method(name: "void handleButtonAction(javafx.event.ActionEvent)", 'class': "animations.SpinnerController")
+        }
+        adjust(replaceContent: true, replaceContentSeparator: ".", includes: "**/*.fxml")
       }
     }
   }

--- a/examples/fxml/settings.gradle
+++ b/examples/fxml/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'fxml'

--- a/examples/fxml/src/main/java/animations/Animations.java
+++ b/examples/fxml/src/main/java/animations/Animations.java
@@ -1,0 +1,43 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package animations;
+
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+
+
+/**
+ *
+ * @author toor
+ */
+public class Animations extends Application {
+    
+    @Override
+    public void start(Stage stage) throws Exception {
+        FXMLLoader spinnerSceneLoader = new FXMLLoader(getClass().getResource("Spinner.fxml"));
+        Parent root = (Parent) spinnerSceneLoader.load();
+        
+        SpinnerController ctrlrPointer = (SpinnerController) spinnerSceneLoader.getController();
+        
+        
+        Scene scene = new Scene(root);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(String[] args) {
+        launch(args);
+    }
+    
+}
+

--- a/examples/fxml/src/main/java/animations/SpinnerController.java
+++ b/examples/fxml/src/main/java/animations/SpinnerController.java
@@ -17,6 +17,7 @@ import javafx.scene.Group;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.util.Duration;
+import com.yworks.util.annotation.Obfuscation;
 
 /**
  *
@@ -45,6 +46,7 @@ public class SpinnerController implements Initializable {
         
         spinSpinner.setOnFinished(new EventHandler<ActionEvent>() {
 
+            @Obfuscation(exclude=true)
             @Override
             public void handle(ActionEvent event) {
                 label.setText("you are on quartile: " + newLoc);

--- a/examples/fxml/src/main/java/animations/SpinnerController.java
+++ b/examples/fxml/src/main/java/animations/SpinnerController.java
@@ -1,0 +1,72 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package animations;
+
+import java.net.URL;
+import java.util.Random;
+import java.util.ResourceBundle;
+import javafx.animation.RotateTransition;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.Group;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.util.Duration;
+
+/**
+ *
+ * @author toor
+ */
+public class SpinnerController implements Initializable {
+
+    private double angleTurned = 0.0;
+    
+    @FXML private Group spinnerPolygon;
+    @FXML private Label label;
+    @FXML private Button button;
+    
+    @FXML
+    private void handleButtonAction(ActionEvent event) {
+        RotateTransition spinSpinner;
+        spinSpinner = new RotateTransition(Duration.millis(1000), spinnerPolygon);
+        double randomNum = angleToSpin();
+        angleTurned = (angleTurned + randomNum) % 360.0;
+        spinSpinner.setByAngle(randomNum);
+        spinSpinner.play();
+        int newLoc = landinglocation(angleTurned);
+
+        System.out.println("newloc: " + newLoc);
+        System.out.println("angleTurned " + angleTurned);
+        
+        spinSpinner.setOnFinished(new EventHandler<ActionEvent>() {
+
+            @Override
+            public void handle(ActionEvent event) {
+                label.setText("you are on quartile: " + newLoc);
+            }
+        });
+        
+
+    }
+
+    private double angleToSpin() {
+        Random r = new Random();
+        return (r.nextDouble() * 720);
+    }
+    
+    private int landinglocation (double d) {
+        return (int) Math.floor((360.0 - d) / 90);
+    }
+
+    @Override
+    public void initialize(URL url, ResourceBundle rb) {
+        // TODO
+    }
+
+}
+

--- a/examples/fxml/src/main/resources/animations/Spinner.fxml
+++ b/examples/fxml/src/main/resources/animations/Spinner.fxml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.shape.*?>
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+<?import javafx.scene.text.TextAlignment?>
+
+<AnchorPane id="AnchorPane" prefHeight="320" prefWidth="400.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="animations.SpinnerController">
+	<children>
+		<Label layoutX="0" layoutY="5" minWidth="400" style="-fx-alignment: center;">
+			<font>
+				<Font size="15" />
+			</font>
+			<text>Hello World</text>
+		</Label>
+		<Button fx:id="button" contentDisplay="CENTER" defaultButton="true" layoutX="161.0" layoutY="272.0" onAction="#handleButtonAction" text="Click Me!" />
+		<Label fx:id="label" layoutX="10" layoutY="30" minHeight="20" minWidth="70">
+			<text>You haven't spun yet!</text>
+		</Label>
+		<Polygon fill="#009918" layoutX="200" layoutY="35" stroke="BLACK" strokeType="OUTSIDE">
+			<points>
+                <Double fx:value="-5.0" />
+                <Double fx:value="4.0" />
+                <Double fx:value="5.0" />
+                <Double fx:value="4.0" />
+                <Double fx:value="0.0" />
+                <Double fx:value="10.0" />
+            </points>
+        </Polygon>
+		<Group fx:id="spinnerPolygon" layoutX="200.0" layoutY="145.0" rotate="0">
+			<children>
+				<Circle fill="DODGERBLUE" layoutX="0" layoutY="5" radius="100.0" stroke="BLACK" strokeType="INSIDE" />
+				<Line endX="100.0" layoutX="0" layoutY="5" />
+				<Line endX="100.0" layoutX="-100.0" layoutY="5" />
+				<Line endX="100.0" layoutX="-50.0" layoutY="-45.0" rotate="90.0" />
+				<Line endX="50.0" layoutX="0" layoutY="55.0" rotate="90.0" startX="-50.0" />
+				<!-- This is a comment -->
+				<Label layoutX="20" layoutY="-20" minHeight="20" minWidth="20" text="0" />
+				<Label layoutX="20" layoutY="20" minHeight="20" minWidth="20" text="1" />
+				<Label layoutX="-20" layoutY="20" minHeight="20" minWidth="20" text="2" />
+				<Label layoutX="-20" layoutY="-20" minHeight="20" minWidth="20" text="3" />
+			</children>
+		</Group>
+	</children>
+</AnchorPane>
+

--- a/src/main/java/com/yworks/yguard/StringReplacer.java
+++ b/src/main/java/com/yworks/yguard/StringReplacer.java
@@ -75,11 +75,11 @@ public class StringReplacer
        result.setLength(0);
        Matcher matcher = pattern.matcher(line);
        String match;
-       String replacement = "";
-       
+
        boolean found = matcher.find();
        while (found)
        {
+         String replacement = "";
          match = line.substring(matcher.start(), matcher.end());
          String[] parts = match.split(Pattern.quote(separator));
          List<String> mapped = db.translateItem(parts);


### PR DESCRIPTION
This example showcases how to use `replaceContent` along with `replaceContentSeparator` to support FXML obfuscation. It requires some work (e.g: method handlers need to removed from obfuscation), but overall is pretty stable. This probably can close #46 