### PR TITLE
Allow subclasses to instantiate their own specialized implementations

### DIFF
--- a/src/main/java/com/yworks/common/ant/YGuardBaseTask.java
+++ b/src/main/java/com/yworks/common/ant/YGuardBaseTask.java
@@ -78,9 +78,19 @@ public abstract class YGuardBaseTask extends Task {
    */
   public AttributesSection createAttribute() {
     if( attributesSections == null ) attributesSections = new ArrayList<AttributesSection>();
-    AttributesSection as = new AttributesSection();
+    AttributesSection as = newAttributesSection();
     attributesSections.add( as );
     return as;
+  }
+
+  /**
+   * Instantiates an attributes section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new attributes section
+   */
+  protected AttributesSection newAttributesSection() {
+    return new AttributesSection();
   }
 
   /**
@@ -90,9 +100,19 @@ public abstract class YGuardBaseTask extends Task {
    */
   public ShrinkBag createInOutPair() {
     if ( pairs == null ) pairs = new ArrayList<ShrinkBag>();
-    ShrinkBag pair = new InOutPair();
+    ShrinkBag pair = newInOutPair();
     pairs.add( pair );
     return pair;
+  }
+
+  /**
+   * Instantiates an in out pair shrink bag,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new shrink bag
+   */
+  protected InOutPair newInOutPair() {
+    return new InOutPair();
   }
 
   /**

--- a/src/main/java/com/yworks/yguard/ObfuscatorTask.java
+++ b/src/main/java/com/yworks/yguard/ObfuscatorTask.java
@@ -659,8 +659,18 @@ public class ObfuscatorTask extends YGuardBaseTask
     if (this.expose != null){
           throw new IllegalArgumentException("Only one expose element allowed!");
       }
-      this.expose = new ExposeSection( this );
+      this.expose = newExposeSection( this );
     return expose;
+  }
+
+  /**
+   * Instantiates the expose section,
+   * subclasses may provide custom implementations.
+   *
+   * @return a new ExposeSection instance
+   */
+  protected ExposeSection newExposeSection( ObfuscatorTask ot ) {
+    return new ExposeSection( ot );
   }
 
   /**
@@ -699,10 +709,20 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @return an AdjustSection instance
    */
   public AdjustSection createAdjust(){
-    AdjustSection adjust = new AdjustSection();
+    AdjustSection adjust = newAdjustSection();
     adjust.setProject(this.getProject());
     adjustSections.add(adjust);
     return adjust;
+  }
+
+  /**
+   * Instantiates an adjust section,
+   * subclasses may provide custom implementations.
+   *
+   * @return a new AdjustSection instance
+   */
+  protected AdjustSection newAdjustSection() {
+    return new AdjustSection();
   }
 
   /**
@@ -723,7 +743,17 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @return the entry points section
    */
   public EntryPointsSection createEntryPoints() {
-    return new EntryPointsSection( this );
+    return newEntryPointsSection( this );
+  }
+
+  /**
+   * Instantiates an entry points section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new entry points section
+   */
+  protected EntryPointsSection newEntryPointsSection( YGuardBaseTask bt ) {
+    return new EntryPointsSection( bt );
   }
 
   /**
@@ -747,8 +777,18 @@ public class ObfuscatorTask extends YGuardBaseTask
       if (this.map != null){
           throw new IllegalArgumentException("Only one map element allowed!");
       }
-      this.map = new MapSection();
+      this.map = newMapSection();
     return map;
+  }
+
+  /**
+   * Instantiates the nested <code>map</code> element,
+   * subclasses may provide custom implementations.
+   *
+   * @return a new instance of MapSection
+   */
+  protected MapSection newMapSection() {
+    return new MapSection();
   }
 
   /**
@@ -772,8 +812,18 @@ public class ObfuscatorTask extends YGuardBaseTask
       if (this.patch != null){
           throw new IllegalArgumentException("Only one patch element allowed!");
       }
-      this.patch = new PatchSection();
+      this.patch = newPatchSection();
     return patch;
+  }
+
+  /**
+   * Instantiates the nested <code>patch</code> element,
+   * subclasses may provide custom implementations.
+   *
+   * @return a new instance of PatchSection
+   */
+  protected PatchSection newPatchSection() {
+    return new PatchSection();
   }
 
   /**
@@ -993,7 +1043,7 @@ public class ObfuscatorTask extends YGuardBaseTask
           }
           filter = new ClassFileFilter(new CollectionFilter(names));
         }
-        GuardDB db = new GuardDB(inFiles);
+        GuardDB db = newGuardDB(inFiles);
 
         if (properties.containsKey("digests")) {
           String digests = (String) properties.get("digests");
@@ -1006,7 +1056,7 @@ public class ObfuscatorTask extends YGuardBaseTask
 
         if (annotationClass != null) db.setAnnotationClass(toNativeClass(annotationClass));
 
-        db.setResourceHandler(new ResourceAdjuster(db));
+        db.setResourceHandler(newResourceAdjuster(db));
         db.setPedantic(pedantic);
         db.setReplaceClassNameStrings(replaceClassNameStrings);
         db.addListener(listener);
@@ -1065,6 +1115,26 @@ public class ObfuscatorTask extends YGuardBaseTask
         // can't do nothing about it
       }
     }
+  }
+
+  /**
+   * Instantiates the classfile database for obfuscation,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new classfile database instance
+   */
+  protected GuardDB newGuardDB(File[] inFile) throws IOException{
+    return new GuardDB(inFile);
+  }
+
+  /**
+   * Instantiates the type Resource adjuster,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new type Resource adjuster instance
+   */
+  protected ResourceAdjuster newResourceAdjuster(GuardDB db) {
+    return new ResourceAdjuster(db);
   }
 
   private void doShrink() {
@@ -1243,16 +1313,16 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * The type Resource adjuster.
    */
-  class ResourceAdjuster implements ResourceHandler
+  protected class ResourceAdjuster implements ResourceHandler
   {
     /**
      * The Db.
      */
-    GuardDB db;
+    protected final GuardDB db;
     /**
      * The Map.
      */
-    Map map;
+    protected final Map map;
     /**
      * The Content replacer.
      */
@@ -1263,7 +1333,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param db the db
      */
-    ResourceAdjuster(final GuardDB db)
+    protected ResourceAdjuster(final GuardDB db)
      {
        this.db = db;
        map = new HashMap() {
@@ -1361,7 +1431,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @return the content replacer
      */
-    StringReplacer getContentReplacer()
+    protected StringReplacer getContentReplacer()
      {
        if(contentReplacer == null)
        {

--- a/src/main/java/com/yworks/yguard/ObfuscatorTask.java
+++ b/src/main/java/com/yworks/yguard/ObfuscatorTask.java
@@ -101,15 +101,15 @@ public class ObfuscatorTask extends YGuardBaseTask
   private String mainClass;
   private boolean conserveManifest = false;
   private File logFile = new File("yguardlog.xml");
-  private ExposeSection expose = null;
-  private List adjustSections = new ArrayList();
-  private MapSection map = null;
-  private PatchSection patch = null;
+  protected ExposeSection expose = null;
+  protected List adjustSections = new ArrayList();
+  protected MapSection map = null;
+  protected PatchSection patch = null;
   //private Path resourceClassPath;
 
   // shrinking attributes
   private boolean doShrink = false;
-  private EntryPointsSection entryPoints = null;
+  protected EntryPointsSection entryPoints = null;
   private File shrinkLog = null;
   private boolean useExposeAsEntryPoints = true;
 

--- a/src/main/java/com/yworks/yguard/ObfuscatorTask.java
+++ b/src/main/java/com/yworks/yguard/ObfuscatorTask.java
@@ -1409,13 +1409,28 @@ public class ObfuscatorTask extends YGuardBaseTask
        for(Iterator iter = adjustSections.iterator(); iter.hasNext();)
        {
          AdjustSection as = (AdjustSection)iter.next();
-         if(as.contains(resourceName) && as.getReplaceContent())
+         if(filterContentImpl(in, out, resourceName, as))
          {
-           Writer writer = new OutputStreamWriter(out);
-           getContentReplacer().replace(new InputStreamReader(in), writer, db, as.replaceContentSeparator);
-           writer.flush();
            return true;
          }
+       }
+       return false;
+     }
+
+     /**
+      * Performs the content filtering for one Adjust section,
+      * subclasses may provide custom implementations.
+      *
+      * @return  {@code true} to terminate filtering once filtering performed
+      */
+     protected boolean filterContentImpl(InputStream in, OutputStream out, String resourceName, AdjustSection as) throws IOException
+     {
+       if(as.contains(resourceName) && as.getReplaceContent())
+       {
+         Writer writer = new OutputStreamWriter(out);
+         getContentReplacer().replace(new InputStreamReader(in), writer, db, as.replaceContentSeparator);
+         writer.flush();
+         return true;
        }
        return false;
      }

--- a/src/main/java/com/yworks/yguard/YGuardTask.java
+++ b/src/main/java/com/yworks/yguard/YGuardTask.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public class YGuardTask extends YGuardBaseTask {
 
-  private List<YGuardBaseTask> subTasks = new ArrayList<YGuardBaseTask>();
+  protected List<YGuardBaseTask> subTasks = new ArrayList<YGuardBaseTask>();
 
   @Override
   public void execute() throws BuildException {

--- a/src/main/java/com/yworks/yguard/YGuardTask.java
+++ b/src/main/java/com/yworks/yguard/YGuardTask.java
@@ -154,10 +154,20 @@ public class YGuardTask extends YGuardBaseTask {
    * @return the shrink task
    */
   public ShrinkTask createShrink() {
-    ShrinkTask shrinkTask = new ShrinkTask( YGuardBaseTask.MODE_NESTED );
+    ShrinkTask shrinkTask = newShrinkTask( YGuardBaseTask.MODE_NESTED );
     configureSubTask(shrinkTask);
     subTasks.add( shrinkTask );
     return shrinkTask;
+  }
+
+  /**
+   * Instantiates a shrink task,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new shrink task
+   */
+  protected ShrinkTask newShrinkTask( boolean mode ) {
+    return new ShrinkTask( mode );
   }
 
   /**
@@ -166,10 +176,20 @@ public class YGuardTask extends YGuardBaseTask {
    * @return the obfuscator task
    */
   public ObfuscatorTask createRename() {
-    ObfuscatorTask obfuscatorTask = new ObfuscatorTask( YGuardBaseTask.MODE_NESTED );
+    ObfuscatorTask obfuscatorTask = newObfuscatorTask( YGuardBaseTask.MODE_NESTED );
     configureSubTask(obfuscatorTask);
     subTasks.add( obfuscatorTask );
     return obfuscatorTask;
+  }
+
+  /**
+   * Instantiates an obfuscator task,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new obfuscator task
+   */
+  protected ObfuscatorTask newObfuscatorTask( boolean mode ) {
+    return new ObfuscatorTask( mode );
   }
 
   private void configureSubTask(Task task) {

--- a/src/main/java/com/yworks/yguard/ant/AttributesSection.java
+++ b/src/main/java/com/yworks/yguard/ant/AttributesSection.java
@@ -9,8 +9,8 @@ import java.util.StringTokenizer;
 /**
  * Used by ant to handle the <code>attributes</code> element.
  */
-public final class AttributesSection extends PatternMatchedClassesSection implements Mappable {
-  private YGuardBaseTask obfuscatorTask;
+public class AttributesSection extends PatternMatchedClassesSection implements Mappable {
+  protected final YGuardBaseTask obfuscatorTask;
 
   /**
    * Instantiates a new Attributes section.

--- a/src/main/java/com/yworks/yguard/ant/ClassSection.java
+++ b/src/main/java/com/yworks/yguard/ant/ClassSection.java
@@ -12,7 +12,7 @@ import java.util.Collection;
 /**
  * Used by ant to handle the <code>class</code> element.
  */
-public final class ClassSection extends PatternMatchedClassesSection implements Mappable {
+public class ClassSection extends PatternMatchedClassesSection implements Mappable {
   private String name;
   private String mapTo;
   private int methodMode = YGuardRule.LEVEL_NONE;
@@ -23,7 +23,7 @@ public final class ClassSection extends PatternMatchedClassesSection implements 
   private String extendsType;
   private String implementsType;
 
-  private final YGuardBaseTask task;
+  protected final YGuardBaseTask task;
 
   /**
    * Instantiates a new Class section.

--- a/src/main/java/com/yworks/yguard/ant/ExposeSection.java
+++ b/src/main/java/com/yworks/yguard/ant/ExposeSection.java
@@ -20,14 +20,14 @@ import java.util.List;
  */
 public class ExposeSection extends Exclude {
 
-  private List classes = new ArrayList( 5 );
-  private List packages = new ArrayList( 5 );
-  private List patterns = new ArrayList( 5 );
-  private List methods = new ArrayList( 5 );
-  private List fields = new ArrayList( 5 );
-  private List attributes = new ArrayList( 5 );
-  private List lineNumberTables = new ArrayList( 5 );
-  private List sourceFiles = new ArrayList( 5 );
+  protected List classes = new ArrayList( 5 );
+  protected List packages = new ArrayList( 5 );
+  protected List patterns = new ArrayList( 5 );
+  protected List methods = new ArrayList( 5 );
+  protected List fields = new ArrayList( 5 );
+  protected List attributes = new ArrayList( 5 );
+  protected List lineNumberTables = new ArrayList( 5 );
+  protected List sourceFiles = new ArrayList( 5 );
 
   /**
    * Instantiates a new Expose section.

--- a/src/main/java/com/yworks/yguard/ant/ExposeSection.java
+++ b/src/main/java/com/yworks/yguard/ant/ExposeSection.java
@@ -2,6 +2,7 @@ package com.yworks.yguard.ant;
 
 import com.yworks.yguard.ObfuscatorTask;
 import com.yworks.common.ant.Exclude;
+import com.yworks.common.ant.YGuardBaseTask;
 import com.yworks.yguard.obf.YGuardRule;
 import com.yworks.yguard.obf.classfile.ClassConstants;
 import org.apache.tools.ant.types.PatternSet;
@@ -52,9 +53,19 @@ public class ExposeSection extends Exclude {
    * @return the method section
    */
   public MethodSection createMethod() {
-    MethodSection ms = new MethodSection();
+    MethodSection ms = newMethodSection();
     this.methods.add( ms );
     return ms;
+  }
+
+  /**
+   * Instantiates a method section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new method section
+   */
+  protected MethodSection newMethodSection() {
+    return new MethodSection();
   }
 
   /**
@@ -63,9 +74,19 @@ public class ExposeSection extends Exclude {
    * @return the field section
    */
   public FieldSection createField() {
-    FieldSection fs = new FieldSection();
+    FieldSection fs = newFieldSection();
     this.fields.add( fs );
     return fs;
+  }
+
+  /**
+   * Instantiates a field section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new field section
+   */
+  protected FieldSection newFieldSection() {
+    return new FieldSection();
   }
 
   /**
@@ -74,9 +95,19 @@ public class ExposeSection extends Exclude {
    * @return the class section
    */
   public ClassSection createClass() {
-    ClassSection cs = new ClassSection( task );
+    ClassSection cs = newClassSection( task );
     this.classes.add( cs );
     return cs;
+  }
+
+  /**
+   * Instantiates a class section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new class section
+   */
+  protected ClassSection newClassSection( YGuardBaseTask bt ) {
+    return new ClassSection( bt );
   }
 
   /**
@@ -85,9 +116,19 @@ public class ExposeSection extends Exclude {
    * @return the package section
    */
   public PackageSection createPackage() {
-    PackageSection ps = new PackageSection();
+    PackageSection ps = newPackageSection();
     this.packages.add( ps );
     return ps;
+  }
+
+  /**
+   * Instantiates a package section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new package section
+   */
+  protected PackageSection newPackageSection() {
+    return new PackageSection();
   }
 
   /**
@@ -96,9 +137,19 @@ public class ExposeSection extends Exclude {
    * @return the attributes section
    */
   public AttributesSection createAttribute() {
-    AttributesSection as = new AttributesSection( task );
+    AttributesSection as = newAttributesSection( task );
     attributes.add( as );
     return as;
+  }
+
+  /**
+   * Instantiates an attributes section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new attributes section
+   */
+  protected AttributesSection newAttributesSection( YGuardBaseTask obfuscatorTask ) {
+    return new AttributesSection( obfuscatorTask );
   }
 
   /**
@@ -107,9 +158,19 @@ public class ExposeSection extends Exclude {
    * @return the line number table section
    */
   public LineNumberTableSection createLineNumberTable() {
-    LineNumberTableSection lns = new LineNumberTableSection( task );
+    LineNumberTableSection lns = newLineNumberTableSection( task );
     lineNumberTables.add( lns );
     return lns;
+  }
+
+  /**
+   * Instantiates a line number table section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new line number table section
+   */
+  protected LineNumberTableSection newLineNumberTableSection( YGuardBaseTask obfuscatorTask ) {
+    return new LineNumberTableSection( obfuscatorTask );
   }
 
   /**
@@ -118,9 +179,19 @@ public class ExposeSection extends Exclude {
    * @return the source file section
    */
   public SourceFileSection createSourceFile() {
-    SourceFileSection sfs = new SourceFileSection( task );
+    SourceFileSection sfs = newSourceFileSection( task );
     sourceFiles.add( sfs );
     return sfs;
+  }
+
+  /**
+   * Instantiates a source file section,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new source file section
+   */
+  protected SourceFileSection newSourceFileSection( YGuardBaseTask obfuscatorTask ) {
+    return new SourceFileSection( obfuscatorTask );
   }
 
   /**

--- a/src/main/java/com/yworks/yguard/ant/FieldSection.java
+++ b/src/main/java/com/yworks/yguard/ant/FieldSection.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 /**
  * Used by ant to handle the <code>field</code> element.
  */
-public final class FieldSection extends PatternMatchedClassesSection implements Mappable {
+public class FieldSection extends PatternMatchedClassesSection implements Mappable {
     private String name;
     private String className;
     private String mapTo;

--- a/src/main/java/com/yworks/yguard/ant/LineNumberTableSection.java
+++ b/src/main/java/com/yworks/yguard/ant/LineNumberTableSection.java
@@ -12,8 +12,8 @@ import java.io.PrintWriter;
 /**
  * Used by ant to handle the <code>attributes</code> element.
  */
-public final class LineNumberTableSection extends PatternMatchedClassesSection implements Mappable {
-  private YGuardBaseTask obfuscatorTask;
+public class LineNumberTableSection extends PatternMatchedClassesSection implements Mappable {
+  protected final YGuardBaseTask obfuscatorTask;
 
   /**
    * Instantiates a new Line number table section.

--- a/src/main/java/com/yworks/yguard/ant/MethodSection.java
+++ b/src/main/java/com/yworks/yguard/ant/MethodSection.java
@@ -8,12 +8,12 @@ import java.util.Collection;
 /**
  * Used by ant to handle the <code>method</code> element.
  */
-public final class MethodSection extends PatternMatchedClassesSection implements Mappable {
+public class MethodSection extends PatternMatchedClassesSection implements Mappable {
     private String name;
     private String className;
     private String mapTo;
 
-//  private final YGuardBaseTask task;
+//  protected final YGuardBaseTask task;
 
 //  public MethodSection( YGuardBaseTask task ) {
 //    this.task = task;

--- a/src/main/java/com/yworks/yguard/ant/PackageSection.java
+++ b/src/main/java/com/yworks/yguard/ant/PackageSection.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 /**
  * Used by ant to handle the <code>package</code> element.
  */
-public final class PackageSection implements Mappable {
+public class PackageSection implements Mappable {
   private String name;
   private String mapTo;
   /**

--- a/src/main/java/com/yworks/yguard/ant/SourceFileSection.java
+++ b/src/main/java/com/yworks/yguard/ant/SourceFileSection.java
@@ -9,8 +9,8 @@ import java.util.Collection;
 /**
  * Used by ant to handle the <code>attributes</code> element.
  */
-public final class SourceFileSection extends PatternMatchedClassesSection implements Mappable {
-  private YGuardBaseTask obfuscatorTask;
+public class SourceFileSection extends PatternMatchedClassesSection implements Mappable {
+  protected final YGuardBaseTask obfuscatorTask;
 
   /**
    * Instantiates a new Source file section.

--- a/src/main/java/com/yworks/yshrink/ant/FieldSection.java
+++ b/src/main/java/com/yworks/yshrink/ant/FieldSection.java
@@ -11,7 +11,7 @@ import java.util.EnumSet;
  *
  * @author Michael Schroeder, yWorks GmbH http://www.yworks.com
  */
-public final class FieldSection extends PatternMatchedSection {
+public class FieldSection extends PatternMatchedSection {
 
   private String name;
   private String className;
@@ -80,9 +80,19 @@ public final class FieldSection extends PatternMatchedSection {
 
   @Override
   public TypePatternSet createPatternSet() {
-    TypePatternSet typePatternSet = new TypePatternSet();
+    TypePatternSet typePatternSet = newTypePatternSet();
     typePatternSet.setType( "class" );
     addPatternSet( typePatternSet, typePatternSet.getType() );
     return typePatternSet;
+  }
+
+  /**
+   * Instantiates a type pattern set,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new type pattern set
+   */
+  protected TypePatternSet newTypePatternSet() {
+    return new TypePatternSet();
   }
 }

--- a/src/main/java/com/yworks/yshrink/ant/MethodSection.java
+++ b/src/main/java/com/yworks/yshrink/ant/MethodSection.java
@@ -10,7 +10,7 @@ import java.util.EnumSet;
 /**
  * Used by ant to handle the <code>method</code> element.
  */
-public final class MethodSection extends PatternMatchedSection {
+public class MethodSection extends PatternMatchedSection {
 
   private String signature;
   private String name;
@@ -151,9 +151,19 @@ public final class MethodSection extends PatternMatchedSection {
   @Override
   public TypePatternSet createPatternSet() {
     System.out.println( "MethodSection.createPatternSet" );
-    TypePatternSet typePatternSet = new TypePatternSet();
+    TypePatternSet typePatternSet = newTypePatternSet();
     typePatternSet.setType( "class" );
     addPatternSet( typePatternSet, typePatternSet.getType() );
     return typePatternSet;
+  }
+
+  /**
+   * Instantiates a type pattern set,
+   * subclasses may provide custom implementations.
+   *
+   * @return the new type pattern set
+   */
+  protected TypePatternSet newTypePatternSet() {
+    return new TypePatternSet();
   }
 }

--- a/src/main/java/com/yworks/yshrink/ant/ShrinkTask.java
+++ b/src/main/java/com/yworks/yshrink/ant/ShrinkTask.java
@@ -325,8 +325,18 @@ public class ShrinkTask extends YGuardBaseTask {
     if ( this.entryPointsSection != null ) {
       throw new IllegalArgumentException( "Only one entrypoints or expose element allowed!" );
     }
-    this.entryPointsSection = new EntryPointsSection( this );
+    this.entryPointsSection = newEntryPointsSection( this );
     return entryPointsSection;
+  }
+
+  /**
+   * Instantiates the nested <code>entryPoint</code> element,
+   * subclasses may provide custom implementations.
+   *
+   * @return a new EntryPointsSection instance
+   */
+  protected EntryPointsSection newEntryPointsSection( YGuardBaseTask bt ) {
+    return new EntryPointsSection( bt );
   }
 
   /**

--- a/src/main/java/com/yworks/yshrink/ant/ShrinkTask.java
+++ b/src/main/java/com/yworks/yshrink/ant/ShrinkTask.java
@@ -38,7 +38,7 @@ public class ShrinkTask extends YGuardBaseTask {
 
   private String digests = "SHA-1,MD5";
 
-  private EntryPointsSection entryPointsSection;
+  protected EntryPointsSection entryPointsSection;
 
   /**
    * Instantiates a new Shrink task.


### PR DESCRIPTION
The emphasis of this commit is to be able to extend to provide our own
custom ResourceAdjuster, along with custom attributes in the related Ant
tasks.

We have replaced the direct instantiation of key classes via the new
operator with calls to protected methods that create the instances.  We
have made this change for Ant tasks and ResourceAdjuster-related
classes.

A couple classes that were package-private are now accessible for
sub-classing.

Furthermore, we have removed "final" from any class that may now have
customized implementations.

Within these classes, we have also exposed some private fields as
"protected final".