### PR TITLE
Update Ant to 1.10.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     annotation project(':annotation')
     implementation project(':annotation')
     implementation 'org.ow2.asm:asm:9.2'
-    implementation 'org.apache.ant:ant:1.10.7'
+    implementation 'org.apache.ant:ant:1.10.12'
     testImplementation 'junit:junit:4.13-beta-3'
 }
 


### PR DESCRIPTION
The current version of Ant, 1.10.7, is potentially vulnerable to [CVE-2020-1945](https://nvd.nist.gov/vuln/detail/CVE-2020-1945). This change updates it to the latest 1.10.x version.