### PR TITLE
Update setup.md for Gradle 7+

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,7 +64,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.yworks:yguard:3.1.0'
+  compileOnly 'com.yworks:yguard:3.1.0'
 }
 
 task yguard {
@@ -75,7 +75,7 @@ task yguard {
     ant.taskdef(
         name: 'yguard',
         classname: 'com.yworks.yguard.YGuardTask',
-        classpath: sourceSets.main.runtimeClasspath.asPath
+        classpath: sourceSets.main.compileClasspath.asPath
     )
 
     ant.yguard {


### PR DESCRIPTION
Adding yGuard to the compile classpath meant that the yGuard jar was added to the created output jar.   Additionally - since Gradle 7.0 'implementation' must be used instead of 'compile'.  However, let's just add yGuard to the compileOnly classpath instead.