### PR TITLE
Passing version check for classes inside Multi-Release path

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
-rootProject.name = 'yguard'
+rootProject.name = 'yGuard'
 include 'annotation'
 include 'retroguard'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,2 @@
 rootProject.name = 'yGuard'
 include 'annotation'
-include 'retroguard'

--- a/src/main/java/com/yworks/yguard/ObfuscatorTask.java
+++ b/src/main/java/com/yworks/yguard/ObfuscatorTask.java
@@ -1107,6 +1107,17 @@ public class ObfuscatorTask extends YGuardBaseTask
         pedantic = true;
       }
     }
+
+    boolean classVersionChecking = true;
+    if (properties.containsKey("class-version-checking")) {
+      String versionCheck = (String) properties.get("class-version-checking");
+      if ("false".equals(versionCheck)) {
+        getProject().log(this, "Class version checking disabled.", Project.MSG_WARN);
+        getProject().log(this, "It's possible cause serious problem in obfuscated result.", Project.MSG_WARN);
+        classVersionChecking = false;
+      }
+    }
+
     getProject().log(this,"Using NameMakerFactory: "+NameMakerFactory.getInstance(), Project.MSG_VERBOSE);
 
     if (pairs == null){
@@ -1219,6 +1230,7 @@ public class ObfuscatorTask extends YGuardBaseTask
 
         db.setResourceHandler(newResourceAdjuster(db));
         db.setPedantic(pedantic);
+        db.setClassVersionChecking(classVersionChecking);
         db.setReplaceClassNameStrings(replaceClassNameStrings);
         db.addListener(listener);
         db.retain(rules, log);

--- a/src/main/java/com/yworks/yguard/ObfuscatorTask.java
+++ b/src/main/java/com/yworks/yguard/ObfuscatorTask.java
@@ -1,14 +1,5 @@
 package com.yworks.yguard;
 
-import com.yworks.util.CollectionFilter;
-import com.yworks.common.ant.ZipScannerTool;
-import com.yworks.yguard.ant.ClassSection;
-import com.yworks.yguard.ant.ExposeSection;
-import com.yworks.yguard.ant.FieldSection;
-import com.yworks.yguard.ant.MapParser;
-import com.yworks.yguard.ant.Mappable;
-import com.yworks.yguard.ant.MethodSection;
-import com.yworks.yguard.ant.PackageSection;
 import com.yworks.common.ShrinkBag;
 import com.yworks.common.ant.AttributesSection;
 import com.yworks.common.ant.EntryPointsSection;
@@ -16,6 +7,16 @@ import com.yworks.common.ant.Exclude;
 import com.yworks.common.ant.InOutPair;
 import com.yworks.common.ant.TypePatternSet;
 import com.yworks.common.ant.YGuardBaseTask;
+import com.yworks.common.ant.ZipScannerTool;
+import com.yworks.util.CollectionFilter;
+import com.yworks.util.Version;
+import com.yworks.yguard.ant.ClassSection;
+import com.yworks.yguard.ant.ExposeSection;
+import com.yworks.yguard.ant.FieldSection;
+import com.yworks.yguard.ant.MapParser;
+import com.yworks.yguard.ant.Mappable;
+import com.yworks.yguard.ant.MethodSection;
+import com.yworks.yguard.ant.PackageSection;
 import com.yworks.yguard.obf.Cl;
 import com.yworks.yguard.obf.Cl.ClassResolver;
 import com.yworks.yguard.obf.ClassTree;
@@ -26,7 +27,6 @@ import com.yworks.yguard.obf.NameMaker;
 import com.yworks.yguard.obf.NameMakerFactory;
 import com.yworks.yguard.obf.NoSuchMappingException;
 import com.yworks.yguard.obf.ResourceHandler;
-import com.yworks.util.Version;
 import com.yworks.yguard.obf.YGuardRule;
 import com.yworks.yguard.obf.classfile.LineNumberInfo;
 import com.yworks.yguard.obf.classfile.LineNumberTableAttrInfo;
@@ -91,8 +91,7 @@ import javax.xml.parsers.SAXParserFactory;
  *
  * @author Sebastian Mueller, yWorks GmbH  (sebastian.mueller@yworks.com)
  */
-public class ObfuscatorTask extends YGuardBaseTask
-{
+public class ObfuscatorTask extends YGuardBaseTask {
 
   //private List pairs = new ArrayList();
   private String mainClass;
@@ -113,14 +112,16 @@ public class ObfuscatorTask extends YGuardBaseTask
   private static final String LOG_TITLE_PRE_VERSION = "  yGuard Bytecode Obfuscator, v";
   private static final String LOG_TITLE_POST_VERSION = ", a Product of yWorks GmbH - http://www.yworks.com";
   private static final String LOG_CREATED = "  Logfile created on ";
-  private static final String LOG_INPUT_FILE =  "  Jar file to be obfuscated:           ";
+  private static final String LOG_INPUT_FILE = "  Jar file to be obfuscated:           ";
   private static final String LOG_OUTPUT_FILE = "  Target Jar file for obfuscated code: ";
 
   private static final String NO_SHRINKING_SUPPORT = "No shrinking support found.";
-  private static final String DEPRECATED  = "The obfuscate task is deprecated. Please use the new com.yworks.yguard.YGuardTask instead.";
+  private static final String DEPRECATED = "The obfuscate task is deprecated. Please use the new com.yworks.yguard.YGuardTask instead.";
 
 
-  /** Holds value of property replaceClassNameStrings. */
+  /**
+   * Holds value of property replaceClassNameStrings.
+   */
   private boolean replaceClassNameStrings = true;
   private File[] tempJars;
   private boolean needYShrinkModel;
@@ -139,21 +140,21 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @param mode the mode
    */
   public ObfuscatorTask( boolean mode ) {
-    super( mode );
+    super(mode);
   }
 
-  private static String toNativePattern(String pattern){
-    if (pattern.endsWith(".class")){
+  private static String toNativePattern( String pattern ) {
+    if (pattern.endsWith(".class")) {
       return pattern;
     } else {
-      if (pattern.endsWith("**")){
-        return pattern.replace('.','/')+"/*.class";
-      } else if (pattern.endsWith("*")){
-        return pattern.replace('.','/')+".class";
-      } else if ( pattern.endsWith( "." ) ) {
-        return pattern.replace( '.', '/' ) + "**/*.class";
+      if (pattern.endsWith("**")) {
+        return pattern.replace('.', '/') + "/*.class";
+      } else if (pattern.endsWith("*")) {
+        return pattern.replace('.', '/') + ".class";
+      } else if (pattern.endsWith(".")) {
+        return pattern.replace('.', '/') + "**/*.class";
       } else {
-        return pattern.replace( '.', '/' ) + ".class";
+        return pattern.replace('.', '/') + ".class";
       }
     }
   }
@@ -164,12 +165,12 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @param patterns the patterns
    * @return the string [ ]
    */
-  public static String[] toNativePattern(String[] patterns){
-    if (patterns == null){
+  public static String[] toNativePattern( String[] patterns ) {
+    if (patterns == null) {
       return new String[0];
     } else {
       String[] res = new String[patterns.length];
-      for (int i = 0; i < patterns.length; i++){
+      for (int i = 0; i < patterns.length; i++) {
         res[i] = toNativePattern(patterns[i]);
       }
       return res;
@@ -182,8 +183,8 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @param className the class name
    * @return the string
    */
-  public static final String toNativeClass(String className){
-    return className.replace('.','/');
+  public static final String toNativeClass( String className ) {
+    return className.replace('.', '/');
   }
 
   /**
@@ -203,7 +204,9 @@ public class ObfuscatorTask extends YGuardBaseTask
     int retarraydim = 0;
     while (tmp.equals("[")) {
       tmp = tokenizer.nextToken();
-      if (!tmp.equals("]")) throw new IllegalArgumentException("']' expected but found " + tmp);
+      if (!tmp.equals("]")) {
+        throw new IllegalArgumentException("']' expected but found " + tmp);
+      }
       retarraydim++;
       tmp = tokenizer.nextToken();
     }
@@ -221,7 +224,9 @@ public class ObfuscatorTask extends YGuardBaseTask
     while (tmp.trim().length() == 0) {
       tmp = tokenizer.nextToken();
     }
-    if (!tmp.equals("(")) throw new IllegalArgumentException("'(' expected but found " + tmp);
+    if (!tmp.equals("(")) {
+      throw new IllegalArgumentException("'(' expected but found " + tmp);
+    }
     tmp = tokenizer.nextToken();
     while (!tmp.equals(")")) {
       while (tmp.trim().length() == 0) {
@@ -235,7 +240,9 @@ public class ObfuscatorTask extends YGuardBaseTask
       int arraydim = 0;
       while (tmp.equals("[")) {
         tmp = tokenizer.nextToken();
-        if (!tmp.equals("]")) throw new IllegalArgumentException("']' expected but found " + tmp);
+        if (!tmp.equals("]")) {
+          throw new IllegalArgumentException("']' expected but found " + tmp);
+        }
         arraydim++;
         tmp = tokenizer.nextToken();
       }
@@ -309,7 +316,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param cs the cs
      */
-    public void addConfiguredClass(ClassSection cs){
+    public void addConfiguredClass( ClassSection cs ) {
       patches.add(cs);
     }
 
@@ -320,24 +327,23 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @return the collection
      * @throws IOException the io exception
      */
-    Collection createEntries(Collection srcJars) throws IOException{
-        Collection entries = new ArrayList(20);
-        for (Iterator it = srcJars.iterator(); it.hasNext();)
-        {
-          File file = (File) it.next();
-          ZipFileSet zipFile = new ZipFileSet();
-          zipFile.setProject(getProject());
-          zipFile.setSrc(file);
-          for (Iterator it2 = patches.iterator(); it2.hasNext();){
-              ClassSection cs = (ClassSection) it2.next();
-              if (cs.getName() == null){
-                cs.addEntries(entries, zipFile);
-              } else {
-                cs.addEntries(entries, cs.getName());
-              }
+    Collection createEntries( Collection srcJars ) throws IOException {
+      Collection entries = new ArrayList(20);
+      for (Iterator it = srcJars.iterator(); it.hasNext(); ) {
+        File file = (File) it.next();
+        ZipFileSet zipFile = new ZipFileSet();
+        zipFile.setProject(getProject());
+        zipFile.setSrc(file);
+        for (Iterator it2 = patches.iterator(); it2.hasNext(); ) {
+          ClassSection cs = (ClassSection) it2.next();
+          if (cs.getName() == null) {
+            cs.addEntries(entries, zipFile);
+          } else {
+            cs.addEntries(entries, cs.getName());
           }
         }
-        return entries;
+      }
+      return entries;
     }
   }
 
@@ -347,13 +353,13 @@ public class ObfuscatorTask extends YGuardBaseTask
    */
   public static final class Modifiers extends EnumeratedAttribute {
     public String[] getValues() {
-        return new String[] {"public", "protected", "friendly", "private","none"};
+      return new String[]{"public", "protected", "friendly", "private", "none"};
     }
 
-    private int myGetIndex(){
+    private int myGetIndex() {
       String[] values = getValues();
-      for (int i = 0; i < values.length; i++){
-        if (getValue().equals(values[i])){
+      for (int i = 0; i < values.length; i++) {
+        if (getValue().equals(values[i])) {
           return i;
         }
       }
@@ -365,12 +371,12 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @return the int
      */
-    public int getModifierValue(){
-      switch (myGetIndex()){
+    public int getModifierValue() {
+      switch (myGetIndex()) {
         default:
-        return YGuardRule.LEVEL_NONE;
+          return YGuardRule.LEVEL_NONE;
         case 0:
-        return YGuardRule.LEVEL_PUBLIC;
+          return YGuardRule.LEVEL_PUBLIC;
         case 1:
           return YGuardRule.LEVEL_PROTECTED;
         case 2:
@@ -387,7 +393,7 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * Used by ant to handle the <code>map</code> element.
    */
-  public final class MapSection{
+  public final class MapSection {
     private File logFile;
     private List mappables = new ArrayList();
 
@@ -396,7 +402,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param ps the ps
      */
-    public void addConfiguredPackage( PackageSection ps){
+    public void addConfiguredPackage( PackageSection ps ) {
       mappables.add(ps);
     }
 
@@ -405,7 +411,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param ps the ps
      */
-    public void addConfiguredClass(ClassSection ps){
+    public void addConfiguredClass( ClassSection ps ) {
       mappables.add(ps);
     }
 
@@ -414,7 +420,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param ps the ps
      */
-    public void addConfiguredField( FieldSection ps){
+    public void addConfiguredField( FieldSection ps ) {
       mappables.add(ps);
     }
 
@@ -423,7 +429,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param ps the ps
      */
-    public void addConfiguredMethod(MethodSection ps){
+    public void addConfiguredMethod( MethodSection ps ) {
       mappables.add(ps);
     }
 
@@ -432,7 +438,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param logFile the log file
      */
-    public void setLogFile(File logFile){
+    public void setLogFile( File logFile ) {
       this.logFile = logFile;
     }
 
@@ -444,42 +450,42 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @return the collection
      * @throws BuildException the build exception
      */
-    Collection createEntries(Project antproject, PrintWriter log) throws BuildException{
+    Collection createEntries( Project antproject, PrintWriter log ) throws BuildException {
       Collection res;
-      if (logFile != null){
-        try{
+      if (logFile != null) {
+        try {
           SAXParserFactory f = SAXParserFactory.newInstance();
           f.setValidating(false);
           SAXParser parser = f.newSAXParser();
           XMLReader r = parser.getXMLReader();
-          MapParser mp = new MapParser( ObfuscatorTask.this );
+          MapParser mp = new MapParser(ObfuscatorTask.this);
           r.setContentHandler(mp);
           Reader reader;
-          if (logFile.getName().endsWith(".gz")){
+          if (logFile.getName().endsWith(".gz")) {
             reader = new InputStreamReader(new GZIPInputStream(new FileInputStream(logFile)));
           } else {
             reader = new FileReader(logFile);
           }
           InputSource source = new InputSource(reader);
-          antproject.log("Parsing logfile's "+logFile.getName()+" map elements...", Project.MSG_INFO);
+          antproject.log("Parsing logfile's " + logFile.getName() + " map elements...", Project.MSG_INFO);
           r.parse(source);
           reader.close();
           r = null;
           f = null;
           parser = null;
           res = mp.getEntries();
-        } catch (ParserConfigurationException pxe){
-          throw new BuildException("Could configure xml parser!",pxe);
-        } catch (SAXException pxe){
-          throw new BuildException("Error parsing xml logfile!"+pxe,pxe);
-        } catch (IOException ioe){
-          throw new BuildException("Could not parse map from logfile!",ioe);
+        } catch (ParserConfigurationException pxe) {
+          throw new BuildException("Could configure xml parser!", pxe);
+        } catch (SAXException pxe) {
+          throw new BuildException("Error parsing xml logfile!" + pxe, pxe);
+        } catch (IOException ioe) {
+          throw new BuildException("Could not parse map from logfile!", ioe);
         }
       } else {
-         res = new ArrayList(mappables.size());
+        res = new ArrayList(mappables.size());
       }
-      for (Iterator it = mappables.iterator(); it.hasNext();){
-        Mappable m = (Mappable)it.next();
+      for (Iterator it = mappables.iterator(); it.hasNext(); ) {
+        Mappable m = (Mappable) it.next();
         m.addMapEntries(res);
       }
       return res;
@@ -497,12 +503,12 @@ public class ObfuscatorTask extends YGuardBaseTask
     private static final int REPLACE_NAME = 8;
     private static final int REPLACE_PATH = 16;
     private static final int REPLACE_PATH_POLICY = 32;
-    
+
     private boolean replaceName = false;
     private boolean replacePath = true;
     private ReplacePathPolicy replacePathPolicy;
     private boolean replaceContent = false;
-    private String  replaceContentSeparator = "/";
+    private String replaceContentSeparator = "/";
     private ReplaceContentPolicy replaceContentPolicy;
 
     private Set entries;
@@ -511,45 +517,46 @@ public class ObfuscatorTask extends YGuardBaseTask
     /**
      * Instantiates a new Adjust section.
      */
-    public AdjustSection()
-    {
+    public AdjustSection() {
     }
 
     /**
      * Determines if the jar entry with the given name has to be adjusted.
+     *
      * @param name the name of the jar entry to check.
      * @return <code>true</code> if the jar entry with the given name will be
      * adjusted; <code>false</code> otherwise.
      */
-    public boolean contains(String name)
-    {
+    public boolean contains( String name ) {
       return entries.contains(name);
     }
 
     /**
      * Specifies if the contents of matched jar entries have to be adjusted.
+     *
      * @param enabled if <code>true</code>, the contents of matched jar entries
-     * will be adjusted.
+     *                will be adjusted.
      */
-    public void setReplaceContent(boolean enabled){
+    public void setReplaceContent( boolean enabled ) {
       this.replaceContent = enabled;
       this.state |= REPLACE_CONTENT;
     }
 
     /**
      * Determines if the contents of matched jar entries have to be adjusted.
+     *
      * @return <code>true</code> if the contents of matched jar entries will be
      * adjusted; <code>false</code> otherwise.
      */
-    public boolean getReplaceContent()
-    {
+    public boolean getReplaceContent() {
       return replaceContent;
     }
 
     /**
      * Specifies the policy for adjusting the content of matched jar entries.
+     *
      * @param policy the policy that determines if and how to adjust the
-     * content of matched jar entries.
+     *               content of matched jar entries.
      */
     public void setReplaceContentPolicy( final ReplaceContentPolicy policy ) {
       this.replaceContentPolicy = policy;
@@ -558,6 +565,7 @@ public class ObfuscatorTask extends YGuardBaseTask
 
     /**
      * Returns the policy for adjusting the content of matched jar entries.
+     *
      * @return the policy that determines if and how to adjust the
      * content of matched jar entries.
      */
@@ -568,9 +576,10 @@ public class ObfuscatorTask extends YGuardBaseTask
     /**
      * Specifies the separator character for finding content class or
      * package identifiers of matched jar entries that have to be adjusted.
+     *
      * @param separator either <code>/</code> or <code>.</code>.
      */
-    public void setReplaceContentSeparator(String separator) {
+    public void setReplaceContentSeparator( String separator ) {
       this.replaceContentSeparator = separator;
       this.state |= REPLACE_CONTENT_SEPARATOR;
     }
@@ -578,6 +587,7 @@ public class ObfuscatorTask extends YGuardBaseTask
     /**
      * Returns the separator character for finding content class or
      * package identifiers of matched jar entries that have to be adjusted.
+     *
      * @return either <code>/</code> or <code>.</code>.
      */
     public String getReplaceContentSeparator() {
@@ -591,11 +601,12 @@ public class ObfuscatorTask extends YGuardBaseTask
      * This property can only be used to prevent adjusting the path of
      * matched jar entries whose name is changed because of
      * {@link #setReplaceName(boolean)}.
+     *
      * @param enabled if <code>false</code>, the path of jar entries that are
-     * renamed will not be changed.
+     *                renamed will not be changed.
      * @see #setReplaceName(boolean)
      */
-    public void setReplacePath(boolean enabled){
+    public void setReplacePath( boolean enabled ) {
       this.replacePath = enabled;
       this.state |= REPLACE_PATH;
     }
@@ -607,12 +618,12 @@ public class ObfuscatorTask extends YGuardBaseTask
      * This property can only be used to prevent adjusting the path of
      * matched jar entries whose name is changed because of
      * {@link #getReplaceName()}.
+     *
      * @return <code>false</code> if the path of jar entries that are
      * renamed will not be changed; <code>true</code> otherwise.
      * @see #getReplaceName()
      */
-    public boolean getReplacePath()
-    {
+    public boolean getReplacePath() {
       return replacePath;
     }
 
@@ -620,6 +631,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      * Determines if the path and name of matched jar entries whose path and name
      * match the qualified name of a renamed class will be adjusted to match the
      * qualified name of the renamed class.
+     *
      * @return <code>true</code> if the path and name of matched jar entries
      * will be adjusted.
      * <p>
@@ -628,8 +640,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      * </p>
      * @see #getReplacePath()
      */
-    public boolean getReplaceName()
-    {
+    public boolean getReplaceName() {
       return replaceName;
     }
 
@@ -641,11 +652,12 @@ public class ObfuscatorTask extends YGuardBaseTask
      * To adjust only the name of matched entries, but not their path,
      * set {@link #setReplacePath(boolean)} to <code>false</code>.
      * </p>
+     *
      * @param enabled if <code>true</code>, the path and name of matched jar
-     * entries will be adjusted.
+     *                entries will be adjusted.
      * @see #setReplacePath(boolean)
      */
-    public void setReplaceName(boolean enabled){
+    public void setReplaceName( boolean enabled ) {
       this.replaceName = enabled;
       this.state |= REPLACE_NAME;
     }
@@ -653,8 +665,9 @@ public class ObfuscatorTask extends YGuardBaseTask
     /**
      * Specifies the policy for adjusting the path to and name of matched jar
      * entries.
+     *
      * @param policy the policy that determines if and how to adjust the path
-     * to and name of matched jar entries.
+     *               to and name of matched jar entries.
      */
     public void setReplacePathPolicy( final ReplacePathPolicy policy ) {
       this.replacePathPolicy = policy;
@@ -664,6 +677,7 @@ public class ObfuscatorTask extends YGuardBaseTask
     /**
      * Returns the policy for adjusting the path to and name of matched jar
      * entries.
+     *
      * @return the policy that determines if and how to adjust the path
      * to and name of matched jar entries.
      */
@@ -678,21 +692,19 @@ public class ObfuscatorTask extends YGuardBaseTask
      * This method has to be called before {@link #contains(String)} can be
      * used.
      * </p>
+     *
      * @param srcJars the set of jar entries to check for matches.
      */
-    public void createEntries(Collection srcJars) throws IOException
-    {
+    public void createEntries( Collection srcJars ) throws IOException {
       entries = new HashSet();
-      for(Iterator iter = srcJars.iterator(); iter.hasNext();)
-      {
+      for (Iterator iter = srcJars.iterator(); iter.hasNext(); ) {
         File file = (File) iter.next();
         setSrc(file);
 
         DirectoryScanner scanner = getDirectoryScanner(getProject());
-        String[] includedFiles  = ZipScannerTool.getMatches(this, scanner);
+        String[] includedFiles = ZipScannerTool.getMatches(this, scanner);
 
-        for(int i = 0; i < includedFiles.length; i++)
-        {
+        for (int i = 0; i < includedFiles.length; i++) {
           entries.add(includedFiles[i]);
         }
       }
@@ -711,9 +723,9 @@ public class ObfuscatorTask extends YGuardBaseTask
       if (newContent) {
         if (oldContent) {
           throw new BuildException(
-            "Invalid adjust configuration, cannot use replaceContent and " +
-            "replaceContentPolicy together. Use replaceContentPolicy only.",
-            getLocation());
+                  "Invalid adjust configuration, cannot use replaceContent and " +
+                  "replaceContentPolicy together. Use replaceContentPolicy only.",
+                  getLocation());
         }
       } else {
         if (oldContent) {
@@ -721,7 +733,7 @@ public class ObfuscatorTask extends YGuardBaseTask
                "replaceContent is deprecated, use replaceContentPolicy instead.");
         }
         setReplaceContentPolicy(getReplaceContent()
-          ? ReplaceContentPolicy.lenient : ReplaceContentPolicy.none);
+                                ? ReplaceContentPolicy.lenient : ReplaceContentPolicy.none);
       }
     }
 
@@ -733,7 +745,7 @@ public class ObfuscatorTask extends YGuardBaseTask
           setReplaceContentSeparator("./");
         } else if (!".".equals(sep) && !"/".equals(sep) && !"./".equals(sep)) {
           throw new BuildException(
-            "Invalid adjust replaceContentSeparator: " + sep, getLocation());
+                  "Invalid adjust replaceContentSeparator: " + sep, getLocation());
         }
       }
     }
@@ -746,15 +758,15 @@ public class ObfuscatorTask extends YGuardBaseTask
       if (newPath) {
         if (oldPath) {
           throw new BuildException(
-            "Invalid adjust configuration, cannot use replacePath and " +
-            "replacePathPolicy together. Use replacePathPolicy only.",
-            getLocation());
+                  "Invalid adjust configuration, cannot use replacePath and " +
+                  "replacePathPolicy together. Use replacePathPolicy only.",
+                  getLocation());
         }
         if (oldName) {
           throw new BuildException(
-            "Invalid adjust configuration, cannot use replaceName and " +
-            "replacePathPolicy together. Use replacePathPolicy only.",
-            getLocation());
+                  "Invalid adjust configuration, cannot use replaceName and " +
+                  "replacePathPolicy together. Use replacePathPolicy only.",
+                  getLocation());
         }
       } else {
         if (oldPath) {
@@ -811,11 +823,11 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @return an ExposeSection instance
    */
-  public ExposeSection createExpose(){
-    if (this.expose != null){
+  public ExposeSection createExpose() {
+    if (this.expose != null) {
       throw new IllegalArgumentException("Only one expose element allowed!");
     }
-    this.expose = newExposeSection( this );
+    this.expose = newExposeSection(this);
     return expose;
   }
 
@@ -826,7 +838,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @return a new ExposeSection instance
    */
   protected ExposeSection newExposeSection( ObfuscatorTask ot ) {
-    return new ExposeSection( ot );
+    return new ExposeSection(ot);
   }
 
   /**
@@ -835,7 +847,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @param entryPoints the entry points
    */
   public void addExcludes( EntryPointsSection entryPoints ) {
-    if ( null == this.expose ) {
+    if (null == this.expose) {
       createExpose();
     }
   }
@@ -845,16 +857,16 @@ public class ObfuscatorTask extends YGuardBaseTask
   }
 
   public void addAttributesSections( List<AttributesSection> attributesSections ) {
-    if ( null != expose ) {
+    if (null != expose) {
       List attributes = expose.getAttributes();
-      for ( AttributesSection attributesSection : attributesSections ) {
-        com.yworks.yguard.ant.AttributesSection asYGuard = new com.yworks.yguard.ant.AttributesSection( this );
+      for (AttributesSection attributesSection : attributesSections) {
+        com.yworks.yguard.ant.AttributesSection asYGuard = new com.yworks.yguard.ant.AttributesSection(this);
         PatternSet patternSet = attributesSection.getPatternSet(TypePatternSet.Type.NAME);
         if (patternSet != null) {
-          asYGuard.addConfiguredPatternSet( patternSet );
+          asYGuard.addConfiguredPatternSet(patternSet);
         }
-        asYGuard.setName( attributesSection.getAttributesStr() );
-        attributes.add( asYGuard );
+        asYGuard.setName(attributesSection.getAttributesStr());
+        attributes.add(asYGuard);
       }
     }
   }
@@ -864,7 +876,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @return an AdjustSection instance
    */
-  public AdjustSection createAdjust(){
+  public AdjustSection createAdjust() {
     AdjustSection adjust = newAdjustSection();
     adjust.setProject(this.getProject());
     adjustSections.add(adjust);
@@ -886,8 +898,8 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param ex the ex
    */
-  public void addConfiguredExpose(ExposeSection ex){
-    if (this.expose != null){
+  public void addConfiguredExpose( ExposeSection ex ) {
+    if (this.expose != null) {
       throw new IllegalArgumentException("Only one expose element allowed!");
     }
     this.expose = ex;
@@ -899,7 +911,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @return the entry points section
    */
   public EntryPointsSection createEntryPoints() {
-    return newEntryPointsSection( this );
+    return newEntryPointsSection(this);
   }
 
   /**
@@ -909,7 +921,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @return the new entry points section
    */
   protected EntryPointsSection newEntryPointsSection( YGuardBaseTask bt ) {
-    return new EntryPointsSection( bt );
+    return new EntryPointsSection(bt);
   }
 
   /**
@@ -918,8 +930,8 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @param eps the eps
    */
   public void addConfiguredEntryPoints( EntryPointsSection eps ) {
-    if ( this.entryPoints != null ) {
-      throw new IllegalArgumentException( "Only one entrypoints element allowed!" );
+    if (this.entryPoints != null) {
+      throw new IllegalArgumentException("Only one entrypoints element allowed!");
     }
     this.entryPoints = eps;
   }
@@ -929,8 +941,8 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @return an instance of MapSection
    */
-  public MapSection createMap(){
-    if (this.map != null){
+  public MapSection createMap() {
+    if (this.map != null) {
       throw new IllegalArgumentException("Only one map element allowed!");
     }
     this.map = newMapSection();
@@ -952,7 +964,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param map the map
    */
-  public void addConfiguredMap(MapSection map){
+  public void addConfiguredMap( MapSection map ) {
     if (this.map != null) {
       throw new IllegalArgumentException("Only one map element allowed!");
     }
@@ -964,7 +976,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @return an instance of PatchSection
    */
-  public PatchSection createPatch(){
+  public PatchSection createPatch() {
     if (this.patch != null) {
       throw new IllegalArgumentException("Only one patch element allowed!");
     }
@@ -987,7 +999,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param patch the patch
    */
-  public void addConfiguredPatch(PatchSection patch){
+  public void addConfiguredPatch( PatchSection patch ) {
     if (this.patch != null) {
       throw new IllegalArgumentException("Only one patch element allowed!");
     }
@@ -1000,7 +1012,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param file the file
    */
-  public void setLogFile(File file){
+  public void setLogFile( File file ) {
     this.logFile = file;
   }
 
@@ -1009,7 +1021,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param c the c
    */
-  public void setConserveManifest(boolean c){
+  public void setConserveManifest( boolean c ) {
     this.conserveManifest = c;
   }
 
@@ -1018,24 +1030,24 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param mainClass the main class
    */
-  public void setMainClass(String mainClass){
+  public void setMainClass( String mainClass ) {
     this.mainClass = mainClass;
   }
 
 
-  /** Used by ant to handle the start the obfuscation process.
+  /**
+   * Used by ant to handle the start the obfuscation process.
    */
-  public void execute() throws BuildException
-  {
+  public void execute() throws BuildException {
     final String msg =
-      "yGuard Obfuscator v" +
-      Version.getVersion() +
-      " - https://www.yworks.com/products/yguard";
+            "yGuard Obfuscator v" +
+            Version.getVersion() +
+            " - https://www.yworks.com/products/yguard";
     getProject().log(this, msg, Project.MSG_INFO);
 
 
-    if ( mode == MODE_STANDALONE ) {
-      getProject().log( this, DEPRECATED, Project.MSG_WARN );
+    if (mode == MODE_STANDALONE) {
+      getProject().log(this, DEPRECATED, Project.MSG_WARN);
     }
 
 
@@ -1049,14 +1061,16 @@ public class ObfuscatorTask extends YGuardBaseTask
 
     TaskLogger taskLogger = new TaskLogger();
 
-    if ( ! ( mode == MODE_STANDALONE ) ) {
+    if (!(mode == MODE_STANDALONE)) {
       doShrink = false;
     }
 
-    if( doShrink ) doShrink();
+    if (doShrink) {
+      doShrink();
+    }
 
     ResourceCpResolver resolver = null;
-    if (resourceClassPath != null){
+    if (resourceClassPath != null) {
       resolver = new ResourceCpResolver(resourceClassPath, this);
       Cl.setClassResolver(resolver);
     }
@@ -1065,45 +1079,45 @@ public class ObfuscatorTask extends YGuardBaseTask
 
     if (properties.containsKey("naming-scheme")
         || properties.containsKey("language-conformity")
-        || properties.containsKey("overload-enabled")){
+        || properties.containsKey("overload-enabled")) {
       String ns = (String) properties.get("naming-scheme");
       String lc = (String) properties.get("language-conformity");
 
       int ilc = YGuardNameFactory.LEGAL;
       int ins = YGuardNameFactory.SMALL;
 
-      if ("compatible".equalsIgnoreCase(lc)){
+      if ("compatible".equalsIgnoreCase(lc)) {
         ilc = YGuardNameFactory.COMPATIBLE;
-      } else if ("illegal".equalsIgnoreCase(lc)){
+      } else if ("illegal".equalsIgnoreCase(lc)) {
         ilc = YGuardNameFactory.ILLEGAL;
       }
-      if ("mix".equalsIgnoreCase(ns)){
+      if ("mix".equalsIgnoreCase(ns)) {
         ins = YGuardNameFactory.MIX;
       }
-      if ("best".equalsIgnoreCase(ns)){
+      if ("best".equalsIgnoreCase(ns)) {
         ins = YGuardNameFactory.BEST;
       }
-      nameFactory = new YGuardNameFactory(ilc|ins);
+      nameFactory = new YGuardNameFactory(ilc | ins);
 
       nameFactory.setPackagePrefix((String) properties.get("obfuscation-prefix"));
     } else {
-      nameFactory = new YGuardNameFactory(YGuardNameFactory.LEGAL|YGuardNameFactory.SMALL);
+      nameFactory = new YGuardNameFactory(YGuardNameFactory.LEGAL | YGuardNameFactory.SMALL);
       nameFactory.setPackagePrefix((String) properties.get("obfuscation-prefix"));
     }
 
     if (properties.containsKey("overload-enabled")) {
       String overload = (String) properties.get("overload-enabled");
       boolean overloadEnabled = true;
-      if( "false".equalsIgnoreCase(overload) || "no".equalsIgnoreCase("overload")) {
+      if ("false".equalsIgnoreCase(overload) || "no".equalsIgnoreCase("overload")) {
         overloadEnabled = false;
       }
       nameFactory.setOverloadEnabled(overloadEnabled);
     }
 
     boolean pedantic = false;
-    if (properties.containsKey("error-checking")){
+    if (properties.containsKey("error-checking")) {
       String ed = (String) properties.get("error-checking");
-      if ("pedantic".equalsIgnoreCase(ed)){
+      if ("pedantic".equalsIgnoreCase(ed)) {
         pedantic = true;
       }
     }
@@ -1118,100 +1132,95 @@ public class ObfuscatorTask extends YGuardBaseTask
       }
     }
 
-    getProject().log(this,"Using NameMakerFactory: "+NameMakerFactory.getInstance(), Project.MSG_VERBOSE);
+    getProject().log(this, "Using NameMakerFactory: " + NameMakerFactory.getInstance(), Project.MSG_VERBOSE);
 
-    if (pairs == null){
+    if (pairs == null) {
       throw new BuildException("No in out pairs specified!");
     }
     Collection inFilesList = new ArrayList(pairs.size());
     File[] inFiles = new File[pairs.size()];
     File[] outFiles = new File[pairs.size()];
-    for (int i = 0; i < pairs.size();i++)
-    {
+    for (int i = 0; i < pairs.size(); i++) {
       InOutPair pair = (InOutPair) pairs.get(i);
-      if (pair.getIn() == null || !pair.getIn().canRead()){
-        throw new BuildException("Cannot open inoutpair.in "+pair.getIn());
+      if (pair.getIn() == null || !pair.getIn().canRead()) {
+        throw new BuildException("Cannot open inoutpair.in " + pair.getIn());
       }
       inFiles[i] = pair.getIn();
       inFilesList.add(pair.getIn());
-      if (pair.getOut() == null){
+      if (pair.getOut() == null) {
         throw new BuildException("Must specify inoutpair.out!");
       }
       outFiles[i] = pair.getOut();
     }
     PrintWriter log = null;
-    if(logFile != null)
-    {
-      try{
-        if (logFile.getName().endsWith(".gz")){
+    if (logFile != null) {
+      try {
+        if (logFile.getName().endsWith(".gz")) {
           log = new PrintWriter(
-            new BufferedWriter(
-              new OutputStreamWriter(
-                new GZIPOutputStream(
-                  new FileOutputStream(logFile)
-                )
-              )
-            )
+                  new BufferedWriter(
+                          new OutputStreamWriter(
+                                  new GZIPOutputStream(
+                                          new FileOutputStream(logFile)
+                                  )
+                          )
+                  )
           );
         } else {
           log = new PrintWriter(new BufferedWriter(new FileWriter(logFile)));
         }
-        taskLogger.setWriter( log );
-      } catch (IOException ioe){
-        getProject().log(this, "Could not create logfile: "+ioe, Project.MSG_ERR);
-          log = new PrintWriter(System.out);
+        taskLogger.setWriter(log);
+      } catch (IOException ioe) {
+        getProject().log(this, "Could not create logfile: " + ioe, Project.MSG_ERR);
+        log = new PrintWriter(System.out);
       }
     } else {
-        log = new PrintWriter(System.out);
+      log = new PrintWriter(System.out);
     }
     writeLogHeader(log, inFiles, outFiles);
-    try{
+    try {
       Collection rules = null;
-      if (expose != null){
+      if (expose != null) {
         rules = expose.createEntries(inFilesList);
       } else {
         rules = new ArrayList(20);
       }
 
-      if (mainClass!= null)
-      {
-          String cn = toNativeClass(mainClass);
-          rules.add(new YGuardRule(YGuardRule.TYPE_CLASS, cn));
-          rules.add(new YGuardRule(YGuardRule.TYPE_METHOD, cn+"/main","([Ljava/lang/String;)V"));
+      if (mainClass != null) {
+        String cn = toNativeClass(mainClass);
+        rules.add(new YGuardRule(YGuardRule.TYPE_CLASS, cn));
+        rules.add(new YGuardRule(YGuardRule.TYPE_METHOD, cn + "/main", "([Ljava/lang/String;)V"));
       }
-      if (map != null){
+      if (map != null) {
         Collection mapEntries = map.createEntries(getProject(), log);
         rules.addAll(mapEntries);
       }
 
-      for (AdjustSection as : adjustSections)
-      {
+      for (AdjustSection as : adjustSections) {
         as.createEntries(inFilesList);
       }
 
-      if (properties.containsKey("expose-attributes")){
-        StringTokenizer st = new StringTokenizer((String)properties.get("expose-attributes"),",",false);
-        while (st.hasMoreTokens()){
+      if (properties.containsKey("expose-attributes")) {
+        StringTokenizer st = new StringTokenizer((String) properties.get("expose-attributes"), ",", false);
+        while (st.hasMoreTokens()) {
           String attribute = st.nextToken().trim();
           rules.add(new YGuardRule(YGuardRule.TYPE_ATTR, attribute));
-          getProject().log(this, "Exposing attribute '"+attribute+"'", Project.MSG_VERBOSE);
+          getProject().log(this, "Exposing attribute '" + attribute + "'", Project.MSG_VERBOSE);
         }
       }
 
-      try
-      {
+      try {
         ObfuscatorTask.LogListener listener = new ObfuscatorTask.LogListener(getProject());
         Filter filter = null;
-        if (patch != null){
+        if (patch != null) {
           getProject().log(this, "Patching...", Project.MSG_INFO);
           Collection patchfiles = patch.createEntries(inFilesList);
           //generate namelist of classes....
           Set names = new HashSet();
-          for (Iterator it = patchfiles.iterator(); it.hasNext();){
-              YGuardRule entry = (YGuardRule) it.next();
-              if (entry.type == YGuardRule.TYPE_CLASS){
-                names.add(entry.name+".class");
-              }
+          for (Iterator it = patchfiles.iterator(); it.hasNext(); ) {
+            YGuardRule entry = (YGuardRule) it.next();
+            if (entry.type == YGuardRule.TYPE_CLASS) {
+              names.add(entry.name + ".class");
+            }
           }
           filter = new ClassFileFilter(new CollectionFilter(names));
         }
@@ -1219,14 +1228,16 @@ public class ObfuscatorTask extends YGuardBaseTask
 
         if (properties.containsKey("digests")) {
           String digests = (String) properties.get("digests");
-          if (digests.trim().equalsIgnoreCase("none")){
+          if (digests.trim().equalsIgnoreCase("none")) {
             db.setDigests(new String[0]);
           } else {
             db.setDigests(digests.split("\\s*,\\s*"));
           }
         }
 
-        if (annotationClass != null) db.setAnnotationClass(toNativeClass(annotationClass));
+        if (annotationClass != null) {
+          db.setAnnotationClass(toNativeClass(annotationClass));
+        }
 
         db.setResourceHandler(newResourceAdjuster(db));
         db.setPedantic(pedantic);
@@ -1236,48 +1247,48 @@ public class ObfuscatorTask extends YGuardBaseTask
         db.retain(rules, log);
         db.remapTo(outFiles, filter, log, conserveManifest);
 
-        for (Iterator it = rules.iterator(); it.hasNext();){
-          ((YGuardRule)it.next()).logProperties(log);
+        for (Iterator it = rules.iterator(); it.hasNext(); ) {
+          ((YGuardRule) it.next()).logProperties(log);
         }
 
         db.close();
         Cl.setClassResolver(null);
 
-        if( doShrink ) {
-          for ( int i = 0; i < tempJars.length; i++ ) {
-            if ( null != tempJars[ i ] ) {
-              tempJars[ i ].delete();
+        if (doShrink) {
+          for (int i = 0; i < tempJars.length; i++) {
+            if (null != tempJars[i]) {
+              tempJars[i].delete();
             }
           }
         }
 
-        if ( !Logger.getInstance().isAllResolved() ) {
-          Logger.getInstance().warning( "Not all dependencies could be resolved. Please see the logfile for details." );
+        if (!Logger.getInstance().isAllResolved()) {
+          Logger.getInstance().warning("Not all dependencies could be resolved. Please see the logfile for details.");
         }
 
-      } catch (NoSuchMappingException nsm){
-        throw new BuildException("yGuard was unable to determine the mapped name for "+nsm.getKey()+".\n Probably broken code. Try recompiling from source!",nsm);
-      } catch (ClassNotFoundException cnfe){
-        throw new BuildException("yGuard was unable to resolve a class ("+cnfe+").\n Probably a missing external dependency.",cnfe);
-      } catch (IOException ioe){
-        if (ioe.getMessage() != null){
+      } catch (NoSuchMappingException nsm) {
+        throw new BuildException("yGuard was unable to determine the mapped name for " + nsm.getKey() + ".\n Probably broken code. Try recompiling from source!", nsm);
+      } catch (ClassNotFoundException cnfe) {
+        throw new BuildException("yGuard was unable to resolve a class (" + cnfe + ").\n Probably a missing external dependency.", cnfe);
+      } catch (IOException ioe) {
+        if (ioe.getMessage() != null) {
           getProject().log(this, ioe.getMessage(), Project.MSG_ERR);
         }
         throw new BuildException("yGuard encountered an IO problem!", ioe);
-      } catch (ParseException pe){
+      } catch (ParseException pe) {
         throw new BuildException("yGuard encountered problems during parsing!", pe);
-      } catch (RuntimeException rte){
-        if (rte.getMessage() != null){
+      } catch (RuntimeException rte) {
+        if (rte.getMessage() != null) {
           getProject().log(this, rte.getMessage(), Project.MSG_ERR);
         }
         rte.printStackTrace();
         throw new BuildException("yGuard encountered an unknown problem!", rte);
-      } finally{
-          writeLogFooter(log);
-          log.flush();
-          log.close();
+      } finally {
+        writeLogFooter(log);
+        log.flush();
+        log.close();
       }
-    } catch (IOException ioe){
+    } catch (IOException ioe) {
       throw new BuildException("yGuard encountered an IO problem!", ioe);
     } finally {
       try {
@@ -1296,7 +1307,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @return the new classfile database instance
    */
-  protected GuardDB newGuardDB(File[] inFile) throws IOException{
+  protected GuardDB newGuardDB( File[] inFile ) throws IOException {
     return new GuardDB(inFile);
   }
 
@@ -1306,7 +1317,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @return the new type Resource adjuster instance
    */
-  protected ResourceAdjuster newResourceAdjuster(GuardDB db) {
+  protected ResourceAdjuster newResourceAdjuster( GuardDB db ) {
     return new ResourceAdjuster(db);
   }
 
@@ -1314,68 +1325,70 @@ public class ObfuscatorTask extends YGuardBaseTask
     YShrinkInvoker yShrinkInvoker = null;
 
     try {
-       yShrinkInvoker = (YShrinkInvoker) Class.forName("com.yworks.yshrink.YShrinkInvokerImpl").newInstance();
-    } catch ( InstantiationException e ) {
-      throw new BuildException( NO_SHRINKING_SUPPORT, e );
-    } catch ( IllegalAccessException e ) {
-      throw new BuildException( NO_SHRINKING_SUPPORT, e );
-    } catch ( ClassNotFoundException e ) {
-      throw new BuildException( NO_SHRINKING_SUPPORT, e );
+      yShrinkInvoker = (YShrinkInvoker) Class.forName("com.yworks.yshrink.YShrinkInvokerImpl").newInstance();
+    } catch (InstantiationException e) {
+      throw new BuildException(NO_SHRINKING_SUPPORT, e);
+    } catch (IllegalAccessException e) {
+      throw new BuildException(NO_SHRINKING_SUPPORT, e);
+    } catch (ClassNotFoundException e) {
+      throw new BuildException(NO_SHRINKING_SUPPORT, e);
     }
 
-    if ( null == yShrinkInvoker ) return;
+    if (null == yShrinkInvoker) {
+      return;
+    }
 
-    yShrinkInvoker.setContext( (Task)this );
+    yShrinkInvoker.setContext((Task) this);
 
-    tempJars = new File[ pairs.size() ];
-    File[] outJars  = new File[ pairs.size() ];
+    tempJars = new File[pairs.size()];
+    File[] outJars = new File[pairs.size()];
 
-    for ( int i = 0; i < tempJars.length; i++ ) {
+    for (int i = 0; i < tempJars.length; i++) {
       try {
-        tempJars[ i ] = File.createTempFile( "tempJar_", "_shrinked.jar", new File(((InOutPair) pairs.get( i )).getOut().getParent()));
-      } catch ( IOException e ) {
-        getProject().log( "Could not create tempfile for shrinking " + tempJars[ i ] + ".", Project.MSG_ERR );
-        tempJars[ i ] = null;
+        tempJars[i] = File.createTempFile("tempJar_", "_shrinked.jar", new File(((InOutPair) pairs.get(i)).getOut().getParent()));
+      } catch (IOException e) {
+        getProject().log("Could not create tempfile for shrinking " + tempJars[i] + ".", Project.MSG_ERR);
+        tempJars[i] = null;
       }
 
-      if ( null != tempJars[ i ] ) {
-        System.out.println( "temp-jar: " + tempJars[ i ] );
-        ShrinkBag pair = ((ShrinkBag) pairs.get( i ));
-        outJars[ i ] = pair.getOut();
-        pair.setOut( tempJars[ i ] );
-        yShrinkInvoker.addPair( pair );
+      if (null != tempJars[i]) {
+        System.out.println("temp-jar: " + tempJars[i]);
+        ShrinkBag pair = ((ShrinkBag) pairs.get(i));
+        outJars[i] = pair.getOut();
+        pair.setOut(tempJars[i]);
+        yShrinkInvoker.addPair(pair);
       }
     }
 
-    yShrinkInvoker.setResourceClassPath( resourceClassPath );
+    yShrinkInvoker.setResourceClassPath(resourceClassPath);
 
-    if ( shrinkLog != null ) {
-      yShrinkInvoker.setLogFile( shrinkLog );
+    if (shrinkLog != null) {
+      yShrinkInvoker.setLogFile(shrinkLog);
     }
 
-    if ( null != entryPoints ) {
-      yShrinkInvoker.setEntyPoints( entryPoints );
+    if (null != entryPoints) {
+      yShrinkInvoker.setEntyPoints(entryPoints);
     }
 
-    if ( null != expose && useExposeAsEntryPoints ) {
-      for ( ClassSection cs : (List<ClassSection>) expose.getClasses()) {
-        yShrinkInvoker.addClassSection( cs );
+    if (null != expose && useExposeAsEntryPoints) {
+      for (ClassSection cs : (List<ClassSection>) expose.getClasses()) {
+        yShrinkInvoker.addClassSection(cs);
       }
-      for ( MethodSection ms : (List<MethodSection>) expose.getMethods()) {
-        yShrinkInvoker.addMethodSection( ms );
+      for (MethodSection ms : (List<MethodSection>) expose.getMethods()) {
+        yShrinkInvoker.addMethodSection(ms);
       }
-      for ( FieldSection fs : (List<FieldSection>) expose.getFields() ) {
-        yShrinkInvoker.addFieldSection( fs );
+      for (FieldSection fs : (List<FieldSection>) expose.getFields()) {
+        yShrinkInvoker.addFieldSection(fs);
       }
     }
 
     yShrinkInvoker.execute();
 
-    for ( int i = 0; i < tempJars.length; i++ ) {
-      if( null != tempJars[ i ] ) {
-        InOutPair pair = ((InOutPair) pairs.get( i ));
-        pair.setIn( tempJars[ i ] );
-        pair.setOut( outJars[ i ] );
+    for (int i = 0; i < tempJars.length; i++) {
+      if (null != tempJars[i]) {
+        InOutPair pair = ((InOutPair) pairs.get(i));
+        pair.setIn(tempJars[i]);
+        pair.setOut(outJars[i]);
       }
     }
   }
@@ -1388,56 +1401,60 @@ public class ObfuscatorTask extends YGuardBaseTask
    */
   public void addInheritanceEntries( Collection entries ) throws IOException {
 
-    if ( ! needYShrinkModel || expose == null ) return;
+    if (!needYShrinkModel || expose == null) {
+      return;
+    }
 
     yShrinkModel = null;
 
     try {
       yShrinkModel = (YShrinkModel) Class.forName("com.yworks.yshrink.YShrinkModelImpl").newInstance();
-    } catch ( InstantiationException e ) {
-      throw new BuildException( NO_SHRINKING_SUPPORT, e );
-    } catch ( IllegalAccessException e ) {
-      throw new BuildException( NO_SHRINKING_SUPPORT, e );
-    } catch ( ClassNotFoundException e ) {
-      throw new BuildException( NO_SHRINKING_SUPPORT, e );
+    } catch (InstantiationException e) {
+      throw new BuildException(NO_SHRINKING_SUPPORT, e);
+    } catch (IllegalAccessException e) {
+      throw new BuildException(NO_SHRINKING_SUPPORT, e);
+    } catch (ClassNotFoundException e) {
+      throw new BuildException(NO_SHRINKING_SUPPORT, e);
     }
 
-    if ( null == yShrinkModel ) return;
+    if (null == yShrinkModel) {
+      return;
+    }
 
     if (this.resourceClassPath != null) {
-      yShrinkModel.setResourceClassPath(this.resourceClassPath,this);
+      yShrinkModel.setResourceClassPath(this.resourceClassPath, this);
     }
 
-    yShrinkModel.createSimpleModel( (List<ShrinkBag>) pairs );
+    yShrinkModel.createSimpleModel((List<ShrinkBag>) pairs);
 
-    for ( String className : yShrinkModel.getAllClassNames() ) {
+    for (String className : yShrinkModel.getAllClassNames()) {
 
-      Set<String> allAncestorClasses = yShrinkModel.getAllAncestorClasses( className );
-      Set<String> allInterfaces = yShrinkModel.getAllImplementedInterfaces( className );
+      Set<String> allAncestorClasses = yShrinkModel.getAllAncestorClasses(className);
+      Set<String> allInterfaces = yShrinkModel.getAllImplementedInterfaces(className);
 
-      for ( ClassSection cs : (List<ClassSection>) expose.getClasses() ) {
+      for (ClassSection cs : (List<ClassSection>) expose.getClasses()) {
 
-        if ( null != cs.getExtends() ) {
+        if (null != cs.getExtends()) {
           String extendsName = cs.getExtends();
-          if ( extendsName.equals( className ) ) {
+          if (extendsName.equals(className)) {
             //System.out.println( extendsName + " equals "+className );
-            cs.addEntries( entries, className );
+            cs.addEntries(entries, className);
           } else {
-            if ( allAncestorClasses.contains( extendsName ) ) {
-              cs.addEntries( entries, className );
+            if (allAncestorClasses.contains(extendsName)) {
+              cs.addEntries(entries, className);
               //System.out.println( extendsName + " extends "+className );
             }
           }
         }
 
-        if ( null != cs.getImplements() ) {
+        if (null != cs.getImplements()) {
           String interfaceName = cs.getImplements();
-          if ( interfaceName.equals( className ) ) {
+          if (interfaceName.equals(className)) {
             //System.out.println( interfaceName + " equals "+className );
-            cs.addEntries( entries, className );
+            cs.addEntries(entries, className);
           } else {
-            if ( allInterfaces.contains( interfaceName ) ) {
-              cs.addEntries( entries, className );
+            if (allInterfaces.contains(interfaceName)) {
+              cs.addEntries(entries, className);
               //System.out.println( interfaceName + " implements "+className );
             }
           }
@@ -1452,11 +1469,11 @@ public class ObfuscatorTask extends YGuardBaseTask
    * @param doShrink the do shrink
    */
   public void setShrink( boolean doShrink ) {
-    if ( mode == MODE_STANDALONE ) {
+    if (mode == MODE_STANDALONE) {
       this.doShrink = doShrink;
     } else {
       throw new BuildException(
-          "The shrink attribute is not supported when the obfuscate task is nested inside a yguard task.\n Use a separate nested shrink task instead." );
+              "The shrink attribute is not supported when the obfuscate task is nested inside a yguard task.\n Use a separate nested shrink task instead.");
     }
   }
 
@@ -1481,8 +1498,7 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * The type Resource adjuster.
    */
-  protected class ResourceAdjuster implements ResourceHandler
-  {
+  protected class ResourceAdjuster implements ResourceHandler {
     /**
      * The Db.
      */
@@ -1493,13 +1509,12 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param db the db
      */
-    protected ResourceAdjuster(final GuardDB db)
-    {
+    protected ResourceAdjuster( final GuardDB db ) {
       this.db = db;
     }
 
     public boolean filterName( final String inName, final StringBuffer outName ) {
-      for(AdjustSection as : adjustSections) {
+      for (AdjustSection as : adjustSections) {
         if (as.contains(inName)) {
           filterNameImpl(inName, outName, as);
           return true;
@@ -1509,37 +1524,37 @@ public class ObfuscatorTask extends YGuardBaseTask
     }
 
     private void filterNameImpl(
-      final String inName, final StringBuffer outName, final AdjustSection as
+            final String inName, final StringBuffer outName, final AdjustSection as
     ) {
       outName.setLength(0);
       final ReplacePathPolicy policy = as.getReplacePathPolicy();
       if (ReplacePathPolicy.file == policy || ReplacePathPolicy.name == policy) {
         translateImpl(
-          inName, outName,
-          ResourceAdjusterUtils.newTranslateServiceFile(db, true),
-          ResourceAdjusterUtils.newTranslateJavaFile(db, true));
+                inName, outName,
+                ResourceAdjusterUtils.newTranslateServiceFile(db, true),
+                ResourceAdjusterUtils.newTranslateJavaFile(db, true));
 
         if (ReplacePathPolicy.name == policy) {
-          String outPath = inName.substring(0,inName.lastIndexOf('/')+1);
+          String outPath = inName.substring(0, inName.lastIndexOf('/') + 1);
           String outFile = outName.toString();
-          outFile = outFile.substring(outFile.lastIndexOf('/')+1);
+          outFile = outFile.substring(outFile.lastIndexOf('/') + 1);
           outName.setLength(0);
           outName.append(outPath);
           outName.append(outFile);
         }
       } else {
         if (ReplacePathPolicy.fileorpath == policy) {
-        translateImpl(
-          inName, outName,
-          ResourceAdjusterUtils.newTranslateServiceFile(db, true),
-          ResourceAdjusterUtils.newTranslateJavaFileOrPath(db));
+          translateImpl(
+                  inName, outName,
+                  ResourceAdjusterUtils.newTranslateServiceFile(db, true),
+                  ResourceAdjusterUtils.newTranslateJavaFileOrPath(db));
         } else if (ReplacePathPolicy.path == policy) {
           outName.append(db.getOutName(inName));
         } else if (ReplacePathPolicy.lenient == policy) {
           translateImpl(
-            inName, outName,
-            ResourceAdjusterUtils.newTranslateServiceFile(db, false),
-            ResourceAdjusterUtils.newTranslateJavaFile(db, false));
+                  inName, outName,
+                  ResourceAdjusterUtils.newTranslateServiceFile(db, false),
+                  ResourceAdjusterUtils.newTranslateJavaFile(db, false));
         } else {
           outName.append(inName);
         }
@@ -1547,10 +1562,10 @@ public class ObfuscatorTask extends YGuardBaseTask
     }
 
     private void translateImpl(
-      final String inName,
-      final StringBuffer outName,
-      final Function<String, String> mapService,
-      final Function<String, String> mapOther
+            final String inName,
+            final StringBuffer outName,
+            final Function<String, String> mapService,
+            final Function<String, String> mapOther
     ) {
       final String servicesPrefix = "META-INF/services/";
       if (inName.startsWith(servicesPrefix)) {
@@ -1576,12 +1591,9 @@ public class ObfuscatorTask extends YGuardBaseTask
       }
     }
 
-    public boolean filterContent(InputStream in, OutputStream out, String resourceName) throws IOException
-    {
-      for(AdjustSection as : adjustSections)
-      {
-        if(filterContentImpl(in, out, resourceName, as))
-        {
+    public boolean filterContent( InputStream in, OutputStream out, String resourceName ) throws IOException {
+      for (AdjustSection as : adjustSections) {
+        if (filterContentImpl(in, out, resourceName, as)) {
           return true;
         }
       }
@@ -1592,16 +1604,14 @@ public class ObfuscatorTask extends YGuardBaseTask
      * Performs the content filtering for one Adjust section,
      * subclasses may provide custom implementations.
      *
-     * @return  {@code true} to terminate filtering once filtering performed
+     * @return {@code true} to terminate filtering once filtering performed
      */
-    protected boolean filterContentImpl(InputStream in, OutputStream out, String resourceName, AdjustSection as) throws IOException
-    {
+    protected boolean filterContentImpl( InputStream in, OutputStream out, String resourceName, AdjustSection as ) throws IOException {
       final ReplaceContentPolicy policy = as.getReplaceContentPolicy();
-      if(as.contains(resourceName) && ReplaceContentPolicy.none != policy)
-      {
+      if (as.contains(resourceName) && ReplaceContentPolicy.none != policy) {
         final String sep = as.getReplaceContentSeparator();
         final Function<String, String> map =
-          newTranslateMapping(db, sep, ReplaceContentPolicy.strict == policy);
+                newTranslateMapping(db, sep, ReplaceContentPolicy.strict == policy);
 
         Writer writer = new OutputStreamWriter(out);
         newContentReplacer(sep).replace(new InputStreamReader(in), writer, map);
@@ -1611,7 +1621,7 @@ public class ObfuscatorTask extends YGuardBaseTask
       return false;
     }
 
-    public String filterString(String in, String resourceName) throws IOException {
+    public String filterString( String in, String resourceName ) throws IOException {
       StringBuffer result = new StringBuffer(in.length());
       newContentReplacer(".").replace(in, result, newTranslateJavaClass(db));
       return result.toString();
@@ -1620,14 +1630,16 @@ public class ObfuscatorTask extends YGuardBaseTask
     protected StringReplacer newContentReplacer( final String separator ) {
       return new StringReplacer(newContentPattern(separator));
     }
-  };
+  }
+
+  ;
 
   private static Function<String, String> newTranslateJavaClass( final GuardDB db ) {
     return ResourceAdjusterUtils.newTranslateJavaClass(db);
   }
 
   private static Function<String, String> newTranslateMapping(
-    final GuardDB db, final String sep, final boolean strict
+          final GuardDB db, final String sep, final boolean strict
   ) {
     return ResourceAdjusterUtils.newTranslateMapping(db, sep, strict);
   }
@@ -1640,7 +1652,7 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * Accepts classes and their nested classes.
    */
-  private static final class ClassFileFilter implements Filter{
+  private static final class ClassFileFilter implements Filter {
     private final com.yworks.util.Filter parent;
 
     /**
@@ -1648,15 +1660,13 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param parent the parent
      */
-    ClassFileFilter(com.yworks.util.Filter parent){
+    ClassFileFilter( com.yworks.util.Filter parent ) {
       this.parent = parent;
     }
 
-    public boolean accepts(Object o)
-    {
+    public boolean accepts( Object o ) {
       String s = (String) o;
-      if (s.endsWith(".class") && s.indexOf('$') != -1)
-      {
+      if (s.endsWith(".class") && s.indexOf('$') != -1) {
         s = s.substring(0, s.indexOf('$')) + ".class";
       }
       return parent.accepts(s);
@@ -1670,7 +1680,7 @@ public class ObfuscatorTask extends YGuardBaseTask
     /**
      * Instantiates a new Task logger.
      */
-    TaskLogger(){
+    TaskLogger() {
       super();
     }
 
@@ -1683,39 +1693,35 @@ public class ObfuscatorTask extends YGuardBaseTask
       this.writer = writer;
     }
 
-    public void warning(String message)
-    {
-      getProject().log(ObfuscatorTask.this, "WARNING: "+message, Project.MSG_WARN);
+    public void warning( String message ) {
+      getProject().log(ObfuscatorTask.this, "WARNING: " + message, Project.MSG_WARN);
 
     }
 
     public void warningToLogfile( String message ) {
-      if ( null != writer ) {
-        writer.println("<!-- " + "WARNING: "+message + " -->");
+      if (null != writer) {
+        writer.println("<!-- " + "WARNING: " + message + " -->");
       }
     }
 
-    public void log(String message)
-    {
+    public void log( String message ) {
       getProject().log(ObfuscatorTask.this, message, Project.MSG_INFO);
     }
 
-    public void error(String message)
-    {
-      getProject().log(ObfuscatorTask.this, "ERROR: "+message, Project.MSG_ERR);
+    public void error( String message ) {
+      getProject().log(ObfuscatorTask.this, "ERROR: " + message, Project.MSG_ERR);
     }
   }
 
-  private void writeLogHeader(PrintWriter log, File[] inFile, File[] outFile)
-  {
+  private void writeLogHeader( PrintWriter log, File[] inFile, File[] outFile ) {
     log.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-    log.println("<yguard version=\""+"1.5"+"\">");
+    log.println("<yguard version=\"" + "1.5" + "\">");
     log.println("<!--");
     log.println(LOG_TITLE_PRE_VERSION + Version.getVersion() + LOG_TITLE_POST_VERSION);
     log.println();
     log.println(LOG_CREATED + new Date().toString());
     log.println();
-    for(int i = 0; i < inFile.length; i++){
+    for (int i = 0; i < inFile.length; i++) {
       log.println(LOG_INPUT_FILE + inFile[i].getName());
       log.println(LOG_OUTPUT_FILE + outFile[i].getName());
       log.println();
@@ -1732,32 +1738,28 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param p the p
      */
-    LogListener(Project p){
+    LogListener( Project p ) {
       this.p = p;
     }
 
-    public void obfuscatingClass(String className)
-    {
-      p.log("Obfuscating class "+className, Project.MSG_VERBOSE);
+    public void obfuscatingClass( String className ) {
+      p.log("Obfuscating class " + className, Project.MSG_VERBOSE);
     }
 
-    public void obfuscatingJar(String inJar, String outJar)
-    {
-      p.log("Obfuscating Jar "+inJar+" to "+outJar);
+    public void obfuscatingJar( String inJar, String outJar ) {
+      p.log("Obfuscating Jar " + inJar + " to " + outJar);
     }
 
-    public void parsingClass(String className)
-    {
-      p.log("Parsing class "+className, Project.MSG_VERBOSE);
+    public void parsingClass( String className ) {
+      p.log("Parsing class " + className, Project.MSG_VERBOSE);
     }
 
-    public void parsingJar(String jar)
-    {
-      p.log("Parsing jar "+jar);
+    public void parsingJar( String jar ) {
+      p.log("Parsing jar " + jar);
     }
   }
 
-  private void writeLogFooter(PrintWriter log){
+  private void writeLogFooter( PrintWriter log ) {
     log.println("</yguard>");
   }
 
@@ -1774,7 +1776,7 @@ public class ObfuscatorTask extends YGuardBaseTask
 
     private String packagePrefix;
 
-    static{
+    static {
       StringBuffer legalC = new StringBuffer(500);
       StringBuffer illegalC = new StringBuffer(500);
       StringBuffer crazyLegalC = new StringBuffer(500);
@@ -1788,22 +1790,22 @@ public class ObfuscatorTask extends YGuardBaseTask
         ObjectInputStream ois = new ObjectInputStream(new GZIPInputStream(ObfuscatorTask.class.getResourceAsStream("jdks.bits")));
         bs = (BitSet[]) ois.readObject();
         ois.close();
-      } catch (IOException ioe){
+      } catch (IOException ioe) {
         throw new InternalError("Could not load valid character bitset!" + ioe.getMessage());
-      } catch (ClassNotFoundException cnfe){
+      } catch (ClassNotFoundException cnfe) {
         throw new InternalError("Could not load valid character bitset!" + cnfe.getMessage());
       }
 
-      for (char i = 0; i < Character.MAX_VALUE; i++){
-        if (!bs[0].get((int)i)) {
+      for (char i = 0; i < Character.MAX_VALUE; i++) {
+        if (!bs[0].get((int) i)) {
           illegalC.append(i);
         } else {
           legalC.append(i);
-          if (i>255){
+          if (i > 255) {
             crazyLegalC.append(i);
-          } else if (i < 128){
+          } else if (i < 128) {
             asciiC.append(i);
-            if (Character.isLowerCase(i)){
+            if (Character.isLowerCase(i)) {
               asciiLC.append(i);
             } else {
               asciiUC.append(i);
@@ -1820,15 +1822,15 @@ public class ObfuscatorTask extends YGuardBaseTask
       legalC.setLength(0);
       illegalC.setLength(0);
       crazyLegalC.setLength(0);
-      for (char i = 0; i < Character.MAX_VALUE; i++){
+      for (char i = 0; i < Character.MAX_VALUE; i++) {
 
-        if (!bs[1].get((int)i)){
+        if (!bs[1].get((int) i)) {
           illegalC.append(i);
         } else {
           legalC.append(i);
-          if (i>255){
+          if (i > 255) {
             crazyLegalC.append(i);
-          } else if (i < 128){
+          } else if (i < 128) {
             asciiC.append(i);
           }
         }
@@ -1875,8 +1877,8 @@ public class ObfuscatorTask extends YGuardBaseTask
     /**
      * Instantiates a new Y guard name factory.
      */
-    YGuardNameFactory(){
-      this(LEGAL|SMALL);
+    YGuardNameFactory() {
+      this(LEGAL | SMALL);
     }
 
     /**
@@ -1884,7 +1886,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param mode the mode
      */
-    YGuardNameFactory(int mode){
+    YGuardNameFactory( int mode ) {
       super.setInstance(this);
       this.mode = mode;
     }
@@ -1900,7 +1902,7 @@ public class ObfuscatorTask extends YGuardBaseTask
       }
     }
 
-    private static String scrambleChars(String string) {
+    private static String scrambleChars( String string ) {
       char[] chars = string.toCharArray();
       Random r = new Random();  // Random number generator
 
@@ -1932,7 +1934,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param overloadEnabled the overload enabled
      */
-    public void setOverloadEnabled(boolean overloadEnabled) {
+    public void setOverloadEnabled( boolean overloadEnabled ) {
       this.overloadEnabled = overloadEnabled;
     }
 
@@ -1941,118 +1943,115 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param prefix the prefix
      */
-    void setPackagePrefix(String prefix){
+    void setPackagePrefix( String prefix ) {
       this.packagePrefix = prefix;
-      if (packagePrefix != null){
-        packagePrefix = packagePrefix.replace('.', '/')+'/';
+      if (packagePrefix != null) {
+        packagePrefix = packagePrefix.replace('.', '/') + '/';
       }
     }
 
-    protected NameMaker createFieldNameMaker(String[] reservedNames, String fqClassName)
-    {
-      switch (mode){
+    protected NameMaker createFieldNameMaker( String[] reservedNames, String fqClassName ) {
+      switch (mode) {
         default:
-        case COMPATIBLE+SMALL:
+        case COMPATIBLE + SMALL:
           LongNameMaker longNameMaker1 = new LongNameMaker(reservedNames,
-              asciiLowerChars, asciiLowerChars, 1);
+                                                           asciiLowerChars, asciiLowerChars, 1);
           longNameMaker1.setOverloadEnabled(overloadEnabled);
           return longNameMaker1;
-        case LEGAL+SMALL:
+        case LEGAL + SMALL:
           LongNameMaker longNameMaker2 = new LongNameMaker(reservedNames,
-              legalFirstChars, legalChars, 1);
+                                                           legalFirstChars, legalChars, 1);
           longNameMaker2.setOverloadEnabled(overloadEnabled);
           return longNameMaker2;
-        case COMPATIBLE+MIX:
-        case LEGAL+MIX:
-            AbstractNameMaker nm1 = new LongNameMaker(reservedNames, false, 6);
-            AbstractNameMaker nm2 = new ObfuscatorTask.KeywordNameMaker(reservedNames);
+        case COMPATIBLE + MIX:
+        case LEGAL + MIX:
+          AbstractNameMaker nm1 = new LongNameMaker(reservedNames, false, 6);
+          AbstractNameMaker nm2 = new ObfuscatorTask.KeywordNameMaker(reservedNames);
           MixNameMaker mixNameMaker1 = new MixNameMaker(null, reservedNames, nm1,
-              3);
+                                                        3);
           MixNameMaker mnm = mixNameMaker1;
-            mnm.add(nm2, 1);
+          mnm.add(nm2, 1);
           mnm.setOverloadEnabled(overloadEnabled);
           return mnm;
-        case COMPATIBLE+BEST:
-        case LEGAL+BEST:
+        case COMPATIBLE + BEST:
+        case LEGAL + BEST:
           LongNameMaker longNameMaker4 = new LongNameMaker(reservedNames, false,
-              256);
+                                                           256);
           KeywordNameMaker keywordNameMaker1 = new KeywordNameMaker(reservedNames);
           CompoundNameMaker compoundNameMaker1 = new CompoundNameMaker(
-            longNameMaker4,
-            keywordNameMaker1);
+                  longNameMaker4,
+                  keywordNameMaker1);
           longNameMaker4.setOverloadEnabled(overloadEnabled);
           keywordNameMaker1.setOverloadEnabled(overloadEnabled);
           return compoundNameMaker1;
-        case ILLEGAL+SMALL:
+        case ILLEGAL + SMALL:
           LongNameMaker longNameMaker3 = new LongNameMaker(reservedNames,
-              crazylegalFirstChars, crazylegalChars, 1);
+                                                           crazylegalFirstChars, crazylegalChars, 1);
           longNameMaker3.setOverloadEnabled(overloadEnabled);
           return longNameMaker3;
-        case ILLEGAL+MIX:
+        case ILLEGAL + MIX:
           nm1 = new LongNameMaker(reservedNames, false, 6);
           nm2 = new ObfuscatorTask.KeywordNameMaker(reservedNames,
-            KeywordNameMaker.KEYWORDS,
-            KeywordNameMaker.SPACER);
+                                                    KeywordNameMaker.KEYWORDS,
+                                                    KeywordNameMaker.SPACER);
           MixNameMaker mixNameMaker2 = new MixNameMaker(null, reservedNames, nm1,
-              2);
+                                                        2);
           mixNameMaker2.add(nm2, 1);
           mixNameMaker2.setOverloadEnabled(overloadEnabled);
           return mixNameMaker2;
-        case ILLEGAL+BEST:
+        case ILLEGAL + BEST:
           nm1 = new ObfuscatorTask.KeywordNameMaker(reservedNames,
-            KeywordNameMaker.KEYWORDS,
-            KeywordNameMaker.SPACER);
-          nm2 = new LongNameMaker(reservedNames,false, 256);
+                                                    KeywordNameMaker.KEYWORDS,
+                                                    KeywordNameMaker.SPACER);
+          nm2 = new LongNameMaker(reservedNames, false, 256);
           mnm = new MixNameMaker(null, reservedNames, nm1,
-              1);
-          mnm.add(nm2,1);
+                                 1);
+          mnm.add(nm2, 1);
           mnm.setOverloadEnabled(overloadEnabled);
           return mnm;
       }
     }
 
-    protected NameMaker createMethodNameMaker(String[] reservedNames, String fqClassName)
-    {
+    protected NameMaker createMethodNameMaker( String[] reservedNames, String fqClassName ) {
       return createFieldNameMaker(reservedNames, fqClassName);
     }
 
-    protected NameMaker createPackageNameMaker(String[] reservedNames, String packageName)
-    {
+    protected NameMaker createPackageNameMaker( String[] reservedNames, String packageName ) {
       boolean topLevel = packageName.length() < 1;
-      switch (mode){
+      switch (mode) {
         default:
-        case COMPATIBLE+SMALL:
-        case COMPATIBLE+MIX:
-        case COMPATIBLE+BEST:
-          if (topLevel && packagePrefix != null){
+        case COMPATIBLE + SMALL:
+        case COMPATIBLE + MIX:
+        case COMPATIBLE + BEST:
+          if (topLevel && packagePrefix != null) {
             return new PrefixNameMaker(packagePrefix, reservedNames, new LongNameMaker(null, asciiLowerChars, asciiLowerChars, 1));
           } else {
             return new LongNameMaker(reservedNames,
-              asciiLowerChars, asciiLowerChars, 1);
+                                     asciiLowerChars, asciiLowerChars, 1);
           }
-        case LEGAL+SMALL:
-        case ILLEGAL+SMALL:
-          if (topLevel && packagePrefix != null){
+        case LEGAL + SMALL:
+        case ILLEGAL + SMALL:
+          if (topLevel && packagePrefix != null) {
             return new PrefixNameMaker(packagePrefix, reservedNames, new LongNameMaker(null, asciiFirstChars, asciiChars, 1));
           } else {
             return new LongNameMaker(reservedNames,
-              asciiFirstChars, asciiChars, 1);
+                                     asciiFirstChars, asciiChars, 1);
           }
-        case LEGAL+MIX:
-        case ILLEGAL+MIX:
-            AbstractNameMaker nm1 = new LongNameMaker(reservedNames,
-            asciiFirstChars, asciiChars, 1);
-            AbstractNameMaker nm3 = new LongNameMaker(reservedNames,true, 256);
-            AbstractNameMaker nm4 = new LongNameMaker(reservedNames,true, 4);
-            AbstractNameMaker nm2 = new ObfuscatorTask.KeywordNameMaker(reservedNames);
-            MixNameMaker mnm = new MixNameMaker(topLevel ? packagePrefix : null, reservedNames, nm1, 8);
-            mnm.add(nm4, 4);
-            mnm.add(nm2, 4);
-            mnm.add(nm3, 1);
-            return mnm;
-        case LEGAL+BEST:
-        case ILLEGAL+BEST:
-          if (topLevel && packagePrefix != null){
+        case LEGAL + MIX:
+        case ILLEGAL + MIX:
+          AbstractNameMaker nm1 = new LongNameMaker(reservedNames,
+                                                    asciiFirstChars, asciiChars, 1);
+          AbstractNameMaker nm3 = new LongNameMaker(reservedNames, true, 256);
+          AbstractNameMaker nm4 = new LongNameMaker(reservedNames, true, 4);
+          AbstractNameMaker nm2 = new ObfuscatorTask.KeywordNameMaker(reservedNames);
+          MixNameMaker mnm = new MixNameMaker(topLevel ? packagePrefix : null, reservedNames, nm1, 8);
+          mnm.add(nm4, 4);
+          mnm.add(nm2, 4);
+          mnm.add(nm3, 1);
+          return mnm;
+        case LEGAL + BEST:
+        case ILLEGAL + BEST:
+          if (topLevel && packagePrefix != null) {
             return new PrefixNameMaker(packagePrefix, reservedNames, new LongNameMaker(null, true, 256));
           } else {
             return new LongNameMaker(reservedNames, true, 256);
@@ -2060,55 +2059,53 @@ public class ObfuscatorTask extends YGuardBaseTask
       }
     }
 
-    protected NameMaker createClassNameMaker(String[] reservedNames, String fqClassName)
-    {
+    protected NameMaker createClassNameMaker( String[] reservedNames, String fqClassName ) {
       return createPackageNameMaker(reservedNames, fqClassName);
     }
 
-    protected NameMaker createInnerClassNameMaker(String[] reservedNames, String fqInnerClassName)
-    {
-      switch (mode){
+    protected NameMaker createInnerClassNameMaker( String[] reservedNames, String fqInnerClassName ) {
+      switch (mode) {
         default:
-        case COMPATIBLE+SMALL:
-        case COMPATIBLE+MIX:
-        case COMPATIBLE+BEST:
+        case COMPATIBLE + SMALL:
+        case COMPATIBLE + MIX:
+        case COMPATIBLE + BEST:
           return new PrefixNameMaker("_", reservedNames, new LongNameMaker(null, asciiLowerChars, asciiLowerChars, 1));
-        case LEGAL+SMALL:
-        return new PrefixNameMaker("_", reservedNames, new LongNameMaker(null, asciiFirstChars, asciiChars, 1));
-        case LEGAL+MIX:
-        return new PrefixNameMaker("_", reservedNames, new LongNameMaker(null,true, 1));
-        case LEGAL+BEST:
-        return new PrefixNameMaker("_", reservedNames, new LongNameMaker(null,true, 4));
-        case ILLEGAL+SMALL:
-        return new LongNameMaker(reservedNames, asciiFirstChars, asciiChars, 1);
-        case ILLEGAL+MIX:
-        return new LongNameMaker(reservedNames,true, 1);
-        case ILLEGAL+BEST:
-        return new LongNameMaker(reservedNames,true, 10);
+        case LEGAL + SMALL:
+          return new PrefixNameMaker("_", reservedNames, new LongNameMaker(null, asciiFirstChars, asciiChars, 1));
+        case LEGAL + MIX:
+          return new PrefixNameMaker("_", reservedNames, new LongNameMaker(null, true, 1));
+        case LEGAL + BEST:
+          return new PrefixNameMaker("_", reservedNames, new LongNameMaker(null, true, 4));
+        case ILLEGAL + SMALL:
+          return new LongNameMaker(reservedNames, asciiFirstChars, asciiChars, 1);
+        case ILLEGAL + MIX:
+          return new LongNameMaker(reservedNames, true, 1);
+        case ILLEGAL + BEST:
+          return new LongNameMaker(reservedNames, true, 10);
       }
     }
 
-    public String toString(){
-      switch (mode){
+    public String toString() {
+      switch (mode) {
         default:
           return "yGuardNameFactory [naming-scheme: default; language-conformity: default]";
-        case COMPATIBLE+SMALL:
+        case COMPATIBLE + SMALL:
           return "yGuardNameFactory [naming-scheme: small; language-conformity: compatible]";
-        case COMPATIBLE+MIX:
+        case COMPATIBLE + MIX:
           return "yGuardNameFactory [naming-scheme: mix; language-conformity: compatible]";
-        case COMPATIBLE+BEST:
+        case COMPATIBLE + BEST:
           return "yGuardNameFactory [naming-scheme: best; language-conformity: compatible]";
-        case LEGAL+SMALL:
+        case LEGAL + SMALL:
           return "yGuardNameFactory [naming-scheme: small; language-conformity: legal]";
-        case LEGAL+MIX:
+        case LEGAL + MIX:
           return "yGuardNameFactory [naming-scheme: mix; language-conformity: legal]";
-        case LEGAL+BEST:
+        case LEGAL + BEST:
           return "yGuardNameFactory [naming-scheme: best; language-conformity: legal]";
-        case ILLEGAL+SMALL:
+        case ILLEGAL + SMALL:
           return "yGuardNameFactory [naming-scheme: small; language-conformity: illegal]";
-        case ILLEGAL+MIX:
+        case ILLEGAL + MIX:
           return "yGuardNameFactory [naming-scheme: mix; language-conformity: illegal]";
-        case ILLEGAL+BEST:
+        case ILLEGAL + BEST:
           return "yGuardNameFactory [naming-scheme: best; language-conformity: illegal]";
       }
     }
@@ -2117,8 +2114,8 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * The type Compound name maker.
    */
-  static class CompoundNameMaker implements NameMaker{
-    private NameMaker nm1,nm2;
+  static class CompoundNameMaker implements NameMaker {
+    private NameMaker nm1, nm2;
 
     /**
      * Instantiates a new Compound name maker.
@@ -2126,14 +2123,13 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param nm1 the nm 1
      * @param nm2 the nm 2
      */
-    CompoundNameMaker(NameMaker nm1, NameMaker nm2){
+    CompoundNameMaker( NameMaker nm1, NameMaker nm2 ) {
       this.nm1 = nm1;
       this.nm2 = nm2;
     }
 
-    public String nextName(String descriptor)
-    {
-      return nm1.nextName(descriptor)+nm2.nextName(descriptor);
+    public String nextName( String descriptor ) {
+      return nm1.nextName(descriptor) + nm2.nextName(descriptor);
     }
   }
 
@@ -2159,7 +2155,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param delegate      the delegate
      * @param count         the count
      */
-    MixNameMaker(String prefix, String[] reservedNames, AbstractNameMaker delegate, int count){
+    MixNameMaker( String prefix, String[] reservedNames, AbstractNameMaker delegate, int count ) {
       super(reservedNames, "O0", 1);
       add(delegate, count);
       this.prefix = prefix;
@@ -2171,20 +2167,19 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param delegate the delegate
      * @param count    the count
      */
-    void add(AbstractNameMaker delegate, int count){
+    void add( AbstractNameMaker delegate, int count ) {
       count = count < 1 ? 1 : count;
-      for (int i = 0; i < count; i++){
+      for (int i = 0; i < count; i++) {
         nameMakers.add(delegate);
       }
       Collections.shuffle(nameMakers);
     }
 
-    String generateName(int i)
-    {
-      if (prefix != null){
-        return prefix + ((AbstractNameMaker)nameMakers.get(i % nameMakers.size())).generateName(i);
+    String generateName( int i ) {
+      if (prefix != null) {
+        return prefix + ((AbstractNameMaker) nameMakers.get(i % nameMakers.size())).generateName(i);
       } else {
-        return ((AbstractNameMaker)nameMakers.get(i % nameMakers.size())).generateName(i);
+        return ((AbstractNameMaker) nameMakers.get(i % nameMakers.size())).generateName(i);
       }
     }
   }
@@ -2192,7 +2187,7 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * The type Long name maker.
    */
-  static final class LongNameMaker extends AbstractNameMaker{
+  static final class LongNameMaker extends AbstractNameMaker {
     /**
      * The Chars.
      */
@@ -2207,7 +2202,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param reservedNames the reserved names
      */
-    LongNameMaker(String[] reservedNames){
+    LongNameMaker( String[] reservedNames ) {
       this(reservedNames, false, 256);
     }
 
@@ -2218,9 +2213,9 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param ascii         the ascii
      * @param length        the length
      */
-    LongNameMaker(String[] reservedNames, boolean ascii, int length){
-      this(reservedNames, ascii?"Oo":"Oo\u00D2\u00D3\u00D4\u00D5\u00D6\u00D8\u00F4\u00F5\u00F6\u00F8",
-      ascii?"Oo0":"0Oo\u00D2\u00D3\u00D4\u00D5\u00D6\u00D8\u00F4\u00F5\u00F6\u00F8",length);
+    LongNameMaker( String[] reservedNames, boolean ascii, int length ) {
+      this(reservedNames, ascii ? "Oo" : "Oo\u00D2\u00D3\u00D4\u00D5\u00D6\u00D8\u00F4\u00F5\u00F6\u00F8",
+           ascii ? "Oo0" : "0Oo\u00D2\u00D3\u00D4\u00D5\u00D6\u00D8\u00F4\u00F5\u00F6\u00F8", length);
     }
 
     /**
@@ -2231,38 +2226,39 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param chars         the chars
      * @param minLength     the min length
      */
-    LongNameMaker(String[] reservedNames, String firstChars, String chars, int minLength){
+    LongNameMaker( String[] reservedNames, String firstChars, String chars, int minLength ) {
       super(reservedNames, null, minLength);
       this.chars = chars;
-      if ( chars == null || chars.length() < 1 ) {
-        throw new IllegalArgumentException( "must specify at least one character!" );
+      if (chars == null || chars.length() < 1) {
+        throw new IllegalArgumentException("must specify at least one character!");
       }
       this.firstChars = firstChars;
-      if (firstChars != null && firstChars.length()<1) this.firstChars = null;
+      if (firstChars != null && firstChars.length() < 1) {
+        this.firstChars = null;
+      }
     }
 
-    String generateName(int i)
-    {
+    String generateName( int i ) {
       StringBuffer sb = new StringBuffer(20);
       int tmp = i;
-      if (firstChars != null){
+      if (firstChars != null) {
         sb.append(firstChars.charAt(tmp % firstChars.length()));
-        if (firstChars.length() > 1){
+        if (firstChars.length() > 1) {
           tmp = tmp / firstChars.length();
         } else {
           tmp--;
         }
       }
-      while (tmp > 0){
+      while (tmp > 0) {
         sb.append(chars.charAt(tmp % chars.length()));
-        if (chars.length()>1){
+        if (chars.length() > 1) {
           tmp = tmp / chars.length();
         } else {
           tmp--;
         }
       }
-      if (chars.length()>1){
-        while (sb.length()< minLength){
+      if (chars.length() > 1) {
+        while (sb.length() < minLength) {
           sb.append(chars.charAt(0));
         }
       }
@@ -2273,19 +2269,19 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * The type Keyword name maker.
    */
-  static final class KeywordNameMaker extends AbstractNameMaker{
+  static final class KeywordNameMaker extends AbstractNameMaker {
     /**
      * The Keywords.
      */
     static final String[] KEYWORDS = new String[]{
-      "this","super","new","Object","String","class","return","void","null","int",
-      "if","float","for","do","while","public","private","interface",};
+            "this", "super", "new", "Object", "String", "class", "return", "void", "null", "int",
+            "if", "float", "for", "do", "while", "public", "private", "interface",};
     /**
      * The Spacer.
      */
     static final String[] SPACER = new String[]{
-      ".","$"," ","_",
-    };
+            ".", "$", " ", "_",
+            };
 
     /**
      * The Nospacer.
@@ -2310,7 +2306,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param reservedNames the reserved names
      */
-    KeywordNameMaker(String[] reservedNames){
+    KeywordNameMaker( String[] reservedNames ) {
       this(reservedNames, KEYWORDS, NOSPACER);
     }
 
@@ -2321,21 +2317,20 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param keyWords      the key words
      * @param spacer        the spacer
      */
-    KeywordNameMaker(String[] reservedNames, String[] keyWords, String[] spacer){
-      super(reservedNames, "Oo0",0);
+    KeywordNameMaker( String[] reservedNames, String[] keyWords, String[] spacer ) {
+      super(reservedNames, "Oo0", 0);
       this.keyWords = keyWords;
       this.spacer = spacer;
     }
 
-    String generateName(int i)
-    {
+    String generateName( int i ) {
       StringBuffer sb = new StringBuffer(30);
       int tmp = i;
       int sc = 0;
-      while (tmp > 0){
+      while (tmp > 0) {
         sb.append(keyWords[tmp % keyWords.length]);
         tmp = tmp / keyWords.length;
-        if (tmp>0){
+        if (tmp > 0) {
           sb.append(spacer[sc % spacer.length]);
           sc++;
         }
@@ -2358,14 +2353,13 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param reservedNames the reserved names
      * @param delegate      the delegate
      */
-    PrefixNameMaker(String prefix, String[] reservedNames, AbstractNameMaker delegate){
+    PrefixNameMaker( String prefix, String[] reservedNames, AbstractNameMaker delegate ) {
       super(reservedNames, "O0", 1);
       this.prefix = prefix;
       this.delegate = delegate;
     }
 
-    String generateName(int i)
-    {
+    String generateName( int i ) {
       return prefix + delegate.generateName(i);
     }
   }
@@ -2373,7 +2367,7 @@ public class ObfuscatorTask extends YGuardBaseTask
   /**
    * The type Abstract name maker.
    */
-  static abstract class AbstractNameMaker implements NameMaker{
+  static abstract class AbstractNameMaker implements NameMaker {
     /**
      * The Reserved names.
      */
@@ -2412,7 +2406,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param overloadEnabled the overload enabled
      */
-    public void setOverloadEnabled(boolean overloadEnabled) {
+    public void setOverloadEnabled( boolean overloadEnabled ) {
       this.overloadEnabled = overloadEnabled;
     }
 
@@ -2422,7 +2416,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param reservedNames the reserved names
      */
-    AbstractNameMaker(String[] reservedNames){
+    AbstractNameMaker( String[] reservedNames ) {
       this(reservedNames, "0o", 256);
     }
 
@@ -2433,28 +2427,29 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param fillChars     the fill chars
      * @param minLength     the min length
      */
-    AbstractNameMaker(String[] reservedNames, String fillChars, int minLength){
-      if (reservedNames!= null && reservedNames.length>0){
+    AbstractNameMaker( String[] reservedNames, String fillChars, int minLength ) {
+      if (reservedNames != null && reservedNames.length > 0) {
         this.reservedNames = new HashSet(Arrays.asList(reservedNames));
       } else {
         this.reservedNames = Collections.EMPTY_SET;
       }
       this.minLength = minLength;
-      this.fillChars = fillChars != null ? fillChars: "0O";
+      this.fillChars = fillChars != null ? fillChars : "0O";
     }
 
-    /** Return the next unique name for this namespace, differing only for identical arg-lists.  */
-    public String nextName(String descriptor)
-    {
-      if (descriptor == null){
+    /**
+     * Return the next unique name for this namespace, differing only for identical arg-lists.
+     */
+    public String nextName( String descriptor ) {
+      if (descriptor == null) {
         descriptor = DUMMY;
       }
       int j;
 
-      if (overloadEnabled){
+      if (overloadEnabled) {
         descriptor = descriptor.substring(0, descriptor.lastIndexOf(')'));
         Integer i = (Integer) countMap.get(descriptor);
-        if (i == null){
+        if (i == null) {
           i = new Integer(1);
         }
         j = i.intValue();
@@ -2462,13 +2457,13 @@ public class ObfuscatorTask extends YGuardBaseTask
         j = counter;
       }
       String result = null;
-      StringBuffer sb = new StringBuffer(minLength>10?minLength+20:20);
+      StringBuffer sb = new StringBuffer(minLength > 10 ? minLength + 20 : 20);
       do {
         sb.setLength(0);
         String name = generateName(j);
         sb.append(name);
-        if (sb.length() < minLength){
-          while (sb.length()<minLength){
+        if (sb.length() < minLength) {
+          while (sb.length() < minLength) {
             sb.append(fillChars);
           }
           sb.setLength(minLength);
@@ -2490,7 +2485,7 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param i the
      * @return the string
      */
-    abstract String generateName(int i);
+    abstract String generateName( int i );
   }
 
   /**
@@ -2512,35 +2507,35 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param resources the resources
      * @param target    the target
      */
-    ResourceCpResolver(Path resources, Task target){
+    ResourceCpResolver( Path resources, Task target ) {
       this.resource = resources;
       String[] list = resources.list();
       List listUrls = new ArrayList();
-      for (int i = 0; i <list.length; i++){
-        try{
+      for (int i = 0; i < list.length; i++) {
+        try {
           URL url = new File(list[i]).toURL();
           listUrls.add(url);
-        } catch (MalformedURLException mfue){
-          target.getProject().log(target, "Could not resolve resource: "+mfue, Project.MSG_WARN);
+        } catch (MalformedURLException mfue) {
+          target.getProject().log(target, "Could not resolve resource: " + mfue, Project.MSG_WARN);
         }
       }
       URL[] urls = new URL[listUrls.size()];
       listUrls.toArray(urls);
       urlClassLoader = URLClassLoader.newInstance(urls, ClassLoader.getSystemClassLoader());
     }
-    public Class resolve(String className) throws ClassNotFoundException
-    {
+
+    public Class resolve( String className ) throws ClassNotFoundException {
       try {
         return Class.forName(className, false, urlClassLoader);
-      } catch (NoClassDefFoundError ncdfe){
+      } catch (NoClassDefFoundError ncdfe) {
         String message = ncdfe.getMessage();
-        if (message == null || message.equals(className)){
+        if (message == null || message.equals(className)) {
           message = className;
         } else {
           message = message + "[" + className + "]";
         }
         throw new ClassNotFoundException(message, ncdfe);
-      } catch (LinkageError le){
+      } catch (LinkageError le) {
         throw new ClassNotFoundException(className, le);
       }
     }
@@ -2556,8 +2551,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param replaceClassNameStrings New value of property replaceClassNameStrings.
    */
-  public void setReplaceClassNameStrings(boolean replaceClassNameStrings)
-  {
+  public void setReplaceClassNameStrings( boolean replaceClassNameStrings ) {
     this.replaceClassNameStrings = replaceClassNameStrings;
   }
 
@@ -2566,7 +2560,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param scramble the scramble
    */
-  public void setScramble(boolean scramble) {
+  public void setScramble( boolean scramble ) {
     if (scramble) {
       YGuardNameFactory.scramble();
       com.yworks.yguard.obf.KeywordNameMaker.scramble();
@@ -2587,17 +2581,17 @@ public class ObfuscatorTask extends YGuardBaseTask
      *
      * @param salt the salt
      */
-    public MyLineNumberTableMapper(long salt){
+    public MyLineNumberTableMapper( long salt ) {
       this.salt = salt;
       this.last = new LineNumberScrambler(3584, lastSeed);
     }
 
-    public boolean mapLineNumberTable(String className, String methodName, String methodSignature, LineNumberTableAttrInfo lineNumberTable) {
-      final String javaClassName = className.replace('/','.').replace('$','.');
+    public boolean mapLineNumberTable( String className, String methodName, String methodSignature, LineNumberTableAttrInfo lineNumberTable ) {
+      final String javaClassName = className.replace('/', '.').replace('$', '.');
       classNames.add(className.replace('/', '.'));
       long seed = salt ^ javaClassName.hashCode();
       LineNumberScrambler scrambler;
-      if (seed == lastSeed){
+      if (seed == lastSeed) {
         scrambler = last;
       } else {
         scrambler = last = new LineNumberScrambler(3584, seed);
@@ -2610,9 +2604,9 @@ public class ObfuscatorTask extends YGuardBaseTask
       return true;
     }
 
-    public void logProperties(PrintWriter pw) {
-      if (!classNames.isEmpty()){
-        for (Iterator it = classNames.iterator(); it.hasNext(); ){
+    public void logProperties( PrintWriter pw ) {
+      if (!classNames.isEmpty()) {
+        for (Iterator it = classNames.iterator(); it.hasNext(); ) {
           pw.println("<property owner=\"" + ClassTree.toUtf8XmlString(it.next().toString()) + "\" name=\"scrambling-salt\" value=\"" + Long.toString(salt) + "\"/>");
         }
         classNames.clear();
@@ -2625,9 +2619,10 @@ public class ObfuscatorTask extends YGuardBaseTask
    */
   public static final class LineNumberSqueezer implements LineNumberTableMapper {
     private List squeezedNumbers = new ArrayList();
-    public boolean mapLineNumberTable(String className, String methodName, String methodSignature, LineNumberTableAttrInfo lineNumberTable) {
+
+    public boolean mapLineNumberTable( String className, String methodName, String methodSignature, LineNumberTableAttrInfo lineNumberTable ) {
       final LineNumberInfo[] table = lineNumberTable.getLineNumberTable();
-      if (table.length > 0){
+      if (table.length > 0) {
         final LineNumberInfo lineNumberInfo = new LineNumberInfo(table[0].getStartPC(), table[0].getLineNumber());
         lineNumberTable.setLineNumberTable(new LineNumberInfo[]{lineNumberInfo});
         squeezedNumbers.add(new Object[]{className, methodName, methodSignature, lineNumberInfo});
@@ -2636,14 +2631,14 @@ public class ObfuscatorTask extends YGuardBaseTask
       return false;
     }
 
-    public void logProperties(PrintWriter pw) {
-      if (!squeezedNumbers.isEmpty()){
-        for (Iterator it = squeezedNumbers.iterator(); it.hasNext();){
+    public void logProperties( PrintWriter pw ) {
+      if (!squeezedNumbers.isEmpty()) {
+        for (Iterator it = squeezedNumbers.iterator(); it.hasNext(); ) {
           Object[] ar = (Object[]) it.next();
           String className = ar[0].toString();
           String methodName = ar[1].toString();
           String methodSignature = ar[2].toString();
-          int line = ((LineNumberInfo)ar[3]).getLineNumber();
+          int line = ((LineNumberInfo) ar[3]).getLineNumber();
           pw.println("<property owner=\"" + ClassTree.toUtf8XmlString(Conversion.toJavaClass(className)) + "#" + ClassTree.toUtf8XmlString(Conversion.toJavaMethod(methodName, methodSignature)) + "\" name=\"squeezed-linenumber\" value=\"" + line + "\"/>");
         }
         squeezedNumbers.clear();
@@ -2664,18 +2659,18 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param size the size
      * @param seed the seed
      */
-    public LineNumberScrambler(int size, long seed){
+    public LineNumberScrambler( int size, long seed ) {
       this.scrambled = new int[size];
       this.unscrambled = new int[size];
-      for (int i = 0; i < size; i++){
+      for (int i = 0; i < size; i++) {
         this.scrambled[i] = i;
         this.unscrambled[i] = i;
       }
       Random r = new Random(seed);
-      for (int i = 0; i < 10; i++){
-        for (int j = 0; j < size; j++){
+      for (int i = 0; i < 10; i++) {
+        for (int j = 0; j < size; j++) {
           int otherIndex = r.nextInt(size);
-          if (otherIndex != j){
+          if (otherIndex != j) {
             int pos1 = this.scrambled[j];
             int pos2 = this.scrambled[otherIndex];
 
@@ -2697,8 +2692,8 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param i the
      * @return the int
      */
-    public int scramble(int i){
-      if (i >= scrambled.length){
+    public int scramble( int i ) {
+      if (i >= scrambled.length) {
         return scrambled[i % scrambled.length] + (i / scrambled.length) * scrambled.length;
       } else {
         return scrambled[i];
@@ -2711,8 +2706,8 @@ public class ObfuscatorTask extends YGuardBaseTask
      * @param i the
      * @return the int
      */
-    public int unscramble(int i){
-      if (i >= scrambled.length){
+    public int unscramble( int i ) {
+      if (i >= scrambled.length) {
         return unscrambled[i % scrambled.length] + (i / scrambled.length) * scrambled.length;
       } else {
         return unscrambled[i];
@@ -2725,7 +2720,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param args the args
    */
-  public static void main(String[] args){
+  public static void main( String[] args ) {
     new LineNumberScrambler(2000, 234432);
   }
 
@@ -2745,7 +2740,7 @@ public class ObfuscatorTask extends YGuardBaseTask
    *
    * @param annotationClass the annotation class
    */
-  public void setAnnotationClass(String annotationClass) {
+  public void setAnnotationClass( String annotationClass ) {
     this.annotationClass = annotationClass;
   }
 
@@ -2760,17 +2755,17 @@ public class ObfuscatorTask extends YGuardBaseTask
     none,
     /**
      * If class obfuscation yields
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      * then text in resource files will be adjusted as follows
-     *   com.yworks.SampleStuff -&gt; A.A.SampleStuff
-     *   com.other.OtherStuff -&gt; A.other.OtherStuff
+     * com.yworks.SampleStuff -&gt; A.A.SampleStuff
+     * com.other.OtherStuff -&gt; A.other.OtherStuff
      */
     lenient,
     /**
      * If class obfuscation yields
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      * then text in resource files will be adjusted as follows
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      */
     strict;
   }
@@ -2786,42 +2781,42 @@ public class ObfuscatorTask extends YGuardBaseTask
     none, // replaceName = false, replacePath = false
     /**
      * If class obfuscation yields
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      * then resource files will be renamed as follows
-     *   com/yworks/SampleStuff.properties -&gt; A/A/SampleStuff.properties
-     *   com/other/OtherStuff.properties -&gt; A/other/OtherStuff.properties
+     * com/yworks/SampleStuff.properties -&gt; A/A/SampleStuff.properties
+     * com/other/OtherStuff.properties -&gt; A/other/OtherStuff.properties
      */
     path, // replaceName = false, replacePath = true, default
     /**
      * If class obfuscation yields
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      * then resource files will be renamed as follows
-     *   com/yworks/SampleStuff.properties -&gt; com/yworks/A.properties
-     *   com/other/OtherStuff.properties -&gt; com/other/OtherStuff.properties
+     * com/yworks/SampleStuff.properties -&gt; com/yworks/A.properties
+     * com/other/OtherStuff.properties -&gt; com/other/OtherStuff.properties
      */
     name, // replaceName = true, replacePath = false
     /**
      * If class obfuscation yields
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      * then resource files will be renamed as follows
-     *   com/yworks/SampleStuff.properties -&gt; A/A/A.properties
-     *   com/other/OtherStuff.properties -&gt; com/other/OtherStuff.properties
+     * com/yworks/SampleStuff.properties -&gt; A/A/A.properties
+     * com/other/OtherStuff.properties -&gt; com/other/OtherStuff.properties
      */
     file, // replaceName = true, replacePath = true
     /**
      * If class obfuscation yields
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      * then resource files will be renamed as follows
-     *   com/yworks/SampleStuff.properties -&gt; A/A/A.properties
-     *   com/other/OtherStuff.properties -&gt; A/other/OtherStuff.properties
+     * com/yworks/SampleStuff.properties -&gt; A/A/A.properties
+     * com/other/OtherStuff.properties -&gt; A/other/OtherStuff.properties
      */
     fileorpath,
     /**
      * If class obfuscation yields
-     *   com.yworks.SampleClass -&gt; A.A.A
+     * com.yworks.SampleClass -&gt; A.A.A
      * then resource files will be renamed as follows
-     *   com/yworks/SampleStuff.properties -&gt; A/A/A.properties
-     *   com/other/OtherStuff.properties -&gt; A/other/OtherStuff.properties
+     * com/yworks/SampleStuff.properties -&gt; A/A/A.properties
+     * com/other/OtherStuff.properties -&gt; A/other/OtherStuff.properties
      */
     lenient
   }

--- a/src/main/java/com/yworks/yguard/obf/GuardDB.java
+++ b/src/main/java/com/yworks/yguard/obf/GuardDB.java
@@ -83,6 +83,8 @@ public class GuardDB implements ClassConstants
   /** Holds value of property pedantic. */
   private boolean pedantic;
 
+  private boolean classVersionChecking;
+
   private ResourceHandler resourceHandler;
   private String[] digestStrings;
 
@@ -379,7 +381,7 @@ public class GuardDB implements ClassConstants
           {
             if (fileFilter == null || fileFilter.accepts(inName)){
               // Write the obfuscated version of the class to the output Jar
-              ClassFile cf = ClassFile.create(inStream, inName.startsWith(GuardDB.MULTI_RELEASE_PREFIX));
+              ClassFile cf = ClassFile.create(inStream, isClassVersionChecking());
               fireObfuscatingClass(Conversion.toJavaClass(cf.getName()));
               cf.remap(classTree, replaceClassNameStrings, log);
               String outName = createClassFileName(inName, cf) + CLASS_EXT;
@@ -718,7 +720,7 @@ public class GuardDB implements ClassConstants
           ClassFile cf = null;
           try
           {
-            cf = ClassFile.create(inStream, name.startsWith(GuardDB.MULTI_RELEASE_PREFIX));
+            cf = ClassFile.create(inStream, isClassVersionChecking());
           }
           catch (Exception e)
           {
@@ -749,7 +751,7 @@ public class GuardDB implements ClassConstants
               } else {
                 if (pedantic){
                   throw new IOException(warning + "\nMake sure these files are of the same version!");
-                } 
+                }
               }
             } else {
               parsedClasses.put(key, new Object[]{new Integer(i), name});
@@ -941,6 +943,13 @@ public class GuardDB implements ClassConstants
     Cl.setPedantic(pedantic);
   }
 
+  public boolean isClassVersionChecking() {
+    return this.classVersionChecking;
+  }
+
+  public void setClassVersionChecking( boolean classVersionChecking ) {
+    this.classVersionChecking = classVersionChecking;
+  }
 
   /**
    * Returns the obfuscated file name of the java class.

--- a/src/main/java/com/yworks/yguard/obf/GuardDB.java
+++ b/src/main/java/com/yworks/yguard/obf/GuardDB.java
@@ -379,7 +379,7 @@ public class GuardDB implements ClassConstants
           {
             if (fileFilter == null || fileFilter.accepts(inName)){
               // Write the obfuscated version of the class to the output Jar
-              ClassFile cf = ClassFile.create(inStream);
+              ClassFile cf = ClassFile.create(inStream, inName.startsWith(GuardDB.MULTI_RELEASE_PREFIX));
               fireObfuscatingClass(Conversion.toJavaClass(cf.getName()));
               cf.remap(classTree, replaceClassNameStrings, log);
               String outName = createClassFileName(inName, cf) + CLASS_EXT;
@@ -697,7 +697,7 @@ public class GuardDB implements ClassConstants
     classTree.setPedantic(isPedantic());
     classTree.setReplaceClassNameStrings(replaceClassNameStrings);
     ClassFile.resetDangerHeader();
-    
+
     Map parsedClasses = new HashMap();
     for(int i = 0; i < inJar.length; i++)
     {
@@ -718,7 +718,7 @@ public class GuardDB implements ClassConstants
           ClassFile cf = null;
           try
           {
-            cf = ClassFile.create(inStream);
+            cf = ClassFile.create(inStream, name.startsWith(GuardDB.MULTI_RELEASE_PREFIX));
           }
           catch (Exception e)
           {

--- a/src/main/java/com/yworks/yguard/obf/GuardDB.java
+++ b/src/main/java/com/yworks/yguard/obf/GuardDB.java
@@ -50,8 +50,7 @@ import java.util.jar.Manifest;
  *
  * @author Mark Welsh
  */
-public class GuardDB implements ClassConstants
-{
+public class GuardDB implements ClassConstants {
   // Constants -------------------------------------------------------------
   private static final String STREAM_NAME_MANIFEST = "META-INF/MANIFEST.MF";
   private static final String MANIFEST_NAME_TAG = "Name";
@@ -74,13 +73,19 @@ public class GuardDB implements ClassConstants
   private ClassTree classTree;    // Tree of packages, classes. methods, fields
   private boolean hasMap = false;
 
-  /** Utility field holding list of Listeners. */
+  /**
+   * Utility field holding list of Listeners.
+   */
   private transient java.util.ArrayList listenerList;
 
-  /** Holds value of property replaceClassNameStrings. */
+  /**
+   * Holds value of property replaceClassNameStrings.
+   */
   private boolean replaceClassNameStrings;
 
-  /** Holds value of property pedantic. */
+  /**
+   * Holds value of property pedantic.
+   */
   private boolean pedantic;
 
   private boolean classVersionChecking;
@@ -100,16 +105,17 @@ public class GuardDB implements ClassConstants
    * @param inFile the in file
    * @throws IOException the io exception
    */
-  public GuardDB(File[] inFile) throws java.io.IOException
-  {
+  public GuardDB( File[] inFile ) throws java.io.IOException {
     inJar = new Archive[inFile.length];
-    for(int i = 0; i < inFile.length; i++)
+    for (int i = 0; i < inFile.length; i++) {
       inJar[i] = Factory.newArchive(inFile[i]);
+    }
   }
 
-  /** Close input JAR file and log-file at GC-time. */
-  protected void finalize() throws java.io.IOException
-  {
+  /**
+   * Close input JAR file and log-file at GC-time.
+   */
+  protected void finalize() throws java.io.IOException {
     close();
   }
 
@@ -118,8 +124,7 @@ public class GuardDB implements ClassConstants
    *
    * @param handler the handler
    */
-  public void setResourceHandler(ResourceHandler handler)
-  {
+  public void setResourceHandler( ResourceHandler handler ) {
     resourceHandler = handler;
   }
 
@@ -129,8 +134,7 @@ public class GuardDB implements ClassConstants
    * @param inName the in name
    * @return the out name
    */
-  public String getOutName(String inName)
-  {
+  public String getOutName( String inName ) {
     return classTree.getOutName(inName);
   }
 
@@ -142,12 +146,10 @@ public class GuardDB implements ClassConstants
    * @param log        the log
    * @throws IOException the io exception
    */
-  public void retain(Collection rgsEntries, PrintWriter log)throws java.io.IOException
-  {
+  public void retain( Collection rgsEntries, PrintWriter log ) throws java.io.IOException {
 
     // Build database if not already done, or if a mapping has already been generated
-    if (classTree == null || hasMap)
-    {
+    if (classTree == null || hasMap) {
       hasMap = false;
       buildClassTree(log);
     }
@@ -161,18 +163,18 @@ public class GuardDB implements ClassConstants
   }
 
   private void retainByAnnotation() {
-    classTree.walkTree(new TreeAction(){
+    classTree.walkTree(new TreeAction() {
 
-      private ObfuscationConfig getApplyingObfuscationConfig(Cl cl){
+      private ObfuscationConfig getApplyingObfuscationConfig( Cl cl ) {
         ObfuscationConfig obfuscationConfig = cl.getObfuscationConfig();
-        if (cl.getObfuscationConfig() != null && obfuscationConfig.applyToMembers){
+        if (cl.getObfuscationConfig() != null && obfuscationConfig.applyToMembers) {
           return obfuscationConfig;
         }
         Cl currentCl = cl;
         // walk to the first class in the parent hierarchy that has applyToMembers set
-        while (currentCl.isInnerClass()){
+        while (currentCl.isInnerClass()) {
           TreeItem parent = currentCl.getParent();
-          if (parent instanceof Cl){
+          if (parent instanceof Cl) {
             currentCl = (Cl) parent;
             ObfuscationConfig parentConfig = currentCl.getObfuscationConfig();
             if (parentConfig != null && parentConfig.applyToMembers) {
@@ -188,20 +190,20 @@ public class GuardDB implements ClassConstants
       }
 
       @Override
-      public void classAction(Cl cl) {
+      public void classAction( Cl cl ) {
         super.classAction(cl);
 
         // iterate over the annotations of the class to see if one specifies the obfuscation
         ObfuscationConfig config = cl.getObfuscationConfig();
 
         if (config != null) {
-          if (config.exclude){
+          if (config.exclude) {
             classTree.retainClass(cl.getFullInName(), YGuardRule.LEVEL_PRIVATE, YGuardRule.LEVEL_NONE, YGuardRule.LEVEL_NONE, true);
           }
         } else {
           // no annotation, check parent hierarchy
           ObfuscationConfig parentConfig = getApplyingObfuscationConfig(cl);
-          if (parentConfig != null && parentConfig.exclude){
+          if (parentConfig != null && parentConfig.exclude) {
             // a parent has annotation that applies his config to members which is: exclude
             classTree.retainClass(cl.getFullInName(), YGuardRule.LEVEL_PRIVATE, YGuardRule.LEVEL_NONE, YGuardRule.LEVEL_NONE, true);
           }
@@ -209,20 +211,20 @@ public class GuardDB implements ClassConstants
       }
 
       @Override
-      public void methodAction(Md md) {
+      public void methodAction( Md md ) {
         super.methodAction(md);
         // iterate over the annotations of the method to see if one specifies the obfuscation
         ObfuscationConfig config = md.getObfuscationConfig();
 
         // annotation at method overrides parent annotation
-        if (config != null){
+        if (config != null) {
           if (config.exclude) {
             classTree.retainMethod(md.getFullInName(), md.getDescriptor());
           }
         } else {
           // no annotation, check parent hierarchy
           ObfuscationConfig parentConfig = getApplyingObfuscationConfig((Cl) md.getParent());
-          if (parentConfig != null && parentConfig.exclude){
+          if (parentConfig != null && parentConfig.exclude) {
             // a parent has annotation that applies his config to members which is: exclude
             classTree.retainMethod(md.getFullInName(), md.getDescriptor());
           }
@@ -230,20 +232,20 @@ public class GuardDB implements ClassConstants
       }
 
       @Override
-      public void fieldAction(Fd fd) {
+      public void fieldAction( Fd fd ) {
         super.fieldAction(fd);
         // iterate over the annotations of the field to see if one specifies the obfuscation
         ObfuscationConfig config = fd.getObfuscationConfig();
 
         // annotation at field overrides parent annotation
-        if (config != null){
+        if (config != null) {
           if (config.exclude) {
             classTree.retainField(fd.getFullInName());
           }
         } else {
           // no annotation, check parent hierarchy
           ObfuscationConfig parentConfig = getApplyingObfuscationConfig((Cl) fd.getParent());
-          if (parentConfig != null && parentConfig.exclude){
+          if (parentConfig != null && parentConfig.exclude) {
             // a parent has annotation that applies his config to members which is: exclude
             classTree.retainField(fd.getFullInName());
           }
@@ -252,16 +254,13 @@ public class GuardDB implements ClassConstants
     });
   }
 
-  private void retainByRule(Collection rgsEntries, PrintWriter log) {
-    for (Iterator it = rgsEntries.iterator(); it.hasNext();)
-    {
-      YGuardRule entry = (YGuardRule)it.next();
-      try
-      {
-        switch (entry.type)
-        {
+  private void retainByRule( Collection rgsEntries, PrintWriter log ) {
+    for (Iterator it = rgsEntries.iterator(); it.hasNext(); ) {
+      YGuardRule entry = (YGuardRule) it.next();
+      try {
+        switch (entry.type) {
           case YGuardRule.TYPE_LINE_NUMBER_MAPPER:
-            classTree.retainLineNumberTable(entry.name,  entry.lineNumberTableMapper);
+            classTree.retainLineNumberTable(entry.name, entry.lineNumberTableMapper);
             break;
           case YGuardRule.TYPE_SOURCE_ATTRIBUTE_MAP:
             classTree.retainSourceFileAttributeMap(entry.name, entry.obfName);
@@ -292,7 +291,7 @@ public class GuardDB implements ClassConstants
             break;
           case YGuardRule.TYPE_METHOD_MAP:
             classTree.retainMethodMap(entry.name, entry.descriptor,
-            entry.obfName);
+                                      entry.obfName);
             break;
           case YGuardRule.TYPE_FIELD_MAP:
             classTree.retainFieldMap(entry.name, entry.obfName);
@@ -300,9 +299,7 @@ public class GuardDB implements ClassConstants
           default:
             throw new ParseException("Illegal type: " + entry.type);
         }
-      }
-      catch (RuntimeException e)
-      {
+      } catch (RuntimeException e) {
         // DEBUG
         // e.printStackTrace();
         log.println(WARNING_SCRIPT_ENTRY_ABSENT + entry.name + " -->");
@@ -320,21 +317,18 @@ public class GuardDB implements ClassConstants
    * @throws IOException            the io exception
    * @throws ClassNotFoundException the class not found exception
    */
-  public void remapTo(File[] out,
-    Filter fileFilter,
-    PrintWriter log,
-    boolean conserveManifest
-    ) throws java.io.IOException, ClassNotFoundException
-  {
+  public void remapTo( File[] out,
+                       Filter fileFilter,
+                       PrintWriter log,
+                       boolean conserveManifest
+  ) throws java.io.IOException, ClassNotFoundException {
     // Build database if not already done
-    if (classTree == null)
-    {
+    if (classTree == null) {
       buildClassTree(log);
     }
 
     // Generate map table if not already done
-    if (!hasMap)
-    {
+    if (!hasMap) {
       createMap(log);
     }
 
@@ -348,38 +342,33 @@ public class GuardDB implements ClassConstants
     ArchiveWriter outJar = null;
     // Open the entry and prepare to process it
     DataInputStream inStream = null;
-    for(int i = 0; i < inJar.length; i++)
-    {
+    for (int i = 0; i < inJar.length; i++) {
       outJar = null;
       //store the whole jar in memory, I known this might be alot, but anyway
       //this is the best option, if you want to create correct jar files...
       List jarEntries = new ArrayList();
-      try
-      {
+      try {
         // Go through the input Jar, removing attributes and remapping the Constant Pool
         // for each class file. Other files are copied through unchanged, except for manifest
         // and any signature files - these are deleted and the manifest is regenerated.
         Enumeration<Entry> entries = inJar[i].getEntries();
         fireObfuscatingJar(inJar[i].getName(), out[i].getName());
         ByteArrayOutputStream baos = new ByteArrayOutputStream(2048);
-        while (entries.hasMoreElements())
-        {
+        while (entries.hasMoreElements()) {
           // Get the next entry from the input Jar
           Entry inEntry = (Entry) entries.nextElement();
 
           // Ignore directories
-          if (inEntry.isDirectory())
-          {
+          if (inEntry.isDirectory()) {
             continue;
           }
 
           inStream = new DataInputStream(
-            new BufferedInputStream(
-            inJar[i].getInputStream(inEntry)));
+                  new BufferedInputStream(
+                          inJar[i].getInputStream(inEntry)));
           String inName = inEntry.getName();
-          if (inName.endsWith(CLASS_EXT))
-          {
-            if (fileFilter == null || fileFilter.accepts(inName)){
+          if (inName.endsWith(CLASS_EXT)) {
+            if (fileFilter == null || fileFilter.accepts(inName)) {
               // Write the obfuscated version of the class to the output Jar
               ClassFile cf = ClassFile.create(inStream, isClassVersionChecking());
               fireObfuscatingClass(Conversion.toJavaClass(cf.getName()));
@@ -388,7 +377,7 @@ public class GuardDB implements ClassConstants
               JarEntry outEntry = new JarEntry(outName);
 
               DataOutputStream classOutputStream;
-              if (digestStrings == null){
+              if (digestStrings == null) {
                 digestStrings = new String[]{"SHA-1", "MD5"};
               }
               MessageDigest[] digests = new MessageDigest[digestStrings.length];
@@ -403,23 +392,18 @@ public class GuardDB implements ClassConstants
               // Now update the manifest entry for the class with new name and new digests
               updateManifest(i, inName, outName, digests);
             }
-          }
-          else if (STREAM_NAME_MANIFEST.equals(inName.toUpperCase()) ||
-            (inName.length() > (SIGNATURE_PREFIX.length() + 1 + SIGNATURE_EXT.length()) &&
-            inName.indexOf(SIGNATURE_PREFIX) != -1 &&
-            inName.substring(inName.length() - SIGNATURE_EXT.length(), inName.length()).equals(SIGNATURE_EXT)))
-          {
+          } else if (STREAM_NAME_MANIFEST.equals(inName.toUpperCase()) ||
+                     (inName.length() > (SIGNATURE_PREFIX.length() + 1 + SIGNATURE_EXT.length()) &&
+                      inName.indexOf(SIGNATURE_PREFIX) != -1 &&
+                      inName.substring(inName.length() - SIGNATURE_EXT.length(), inName.length()).equals(SIGNATURE_EXT))) {
             // Don't pass through the manifest or signature files
             continue;
-          }
-          else
-          {
+          } else {
             // Copy the non-class entry through unchanged
             long size = inEntry.getSize();
-            if (size != -1)
-            {
+            if (size != -1) {
 
-              if (digestStrings == null){
+              if (digestStrings == null) {
                 digestStrings = new String[]{"SHA-1", "MD5"};
               }
               MessageDigest[] digests = new MessageDigest[digestStrings.length];
@@ -429,34 +413,27 @@ public class GuardDB implements ClassConstants
 
               StringBuffer outNameBuffer = new StringBuffer(80);
 
-              if(resourceHandler != null && resourceHandler.filterName(inName, outNameBuffer))
-              {
+              if (resourceHandler != null && resourceHandler.filterName(inName, outNameBuffer)) {
                 outName = outNameBuffer.toString();
-                if(!outName.equals(inName))
-                {
+                if (!outName.equals(inName)) {
                   replaceNameLog.append("  <resource name=\"");
                   replaceNameLog.append(ClassTree.toUtf8XmlString(inName));
                   replaceNameLog.append("\" map=\"");
                   replaceNameLog.append(ClassTree.toUtf8XmlString(outName));
                   replaceNameLog.append("\"/>\n");
                 }
-              }
-              else
-              {
+              } else {
                 outName = classTree.getOutName(inName);
               }
 
-              if(resourceHandler == null || !resourceHandler.filterContent(inStream, dataOutputStream, inName))
-              {
-                byte[] bytes = new byte[(int)size];
+              if (resourceHandler == null || !resourceHandler.filterContent(inStream, dataOutputStream, inName)) {
+                byte[] bytes = new byte[(int) size];
                 inStream.readFully(bytes);
 
                 // outName = classTree.getOutName(inName);
                 // Dump the data, while creating the digests
                 dataOutputStream.write(bytes, 0, bytes.length);
-              }
-              else
-              {
+              } else {
                 replaceContentsLog.append("  <resource name=\"");
                 replaceContentsLog.append(ClassTree.toUtf8XmlString(inName));
                 replaceContentsLog.append("\"/>\n");
@@ -469,12 +446,12 @@ public class GuardDB implements ClassConstants
               jarEntries.add(new Object[]{outEntry, baos.toByteArray()});
               baos.reset();
               // Now update the manifest entry for the entry with new name and new digests
-              updateManifest(i , inName, outName, digests);
+              updateManifest(i, inName, outName, digests);
             }
           }
         }
 
-        if (conserveManifest){
+        if (conserveManifest) {
           outJar = Factory.newArchiveWriter(out[i], oldManifest[i]);
         } else {
           outJar = Factory.newArchiveWriter(out[i], newManifest[i]);
@@ -484,8 +461,8 @@ public class GuardDB implements ClassConstants
         }
 
         // sort the entries in ascending order
-        Collections.sort(jarEntries, new Comparator(){
-          public int compare(Object a, Object b){
+        Collections.sort(jarEntries, new Comparator() {
+          public int compare( Object a, Object b ) {
             Object[] array1 = (Object[]) a;
             JarEntry entry1 = (JarEntry) array1[0];
             Object[] array2 = (Object[]) b;
@@ -495,16 +472,16 @@ public class GuardDB implements ClassConstants
         });
         // Finally, write the big bunch of data
         Set directoriesWritten = new HashSet();
-        for (int j = 0; j < jarEntries.size(); j++){
+        for (int j = 0; j < jarEntries.size(); j++) {
           Object[] array = (Object[]) jarEntries.get(j);
           JarEntry entry = (JarEntry) array[0];
           String name = entry.getName();
           // make sure the directory entries are written to the jar file
-          if (!entry.isDirectory()){
+          if (!entry.isDirectory()) {
             int index = 0;
-            while ((index = name.indexOf("/", index + 1))>= 0){
-              String directory = name.substring(0, index+1);
-              if (!directoriesWritten.contains(directory)){
+            while ((index = name.indexOf("/", index + 1)) >= 0) {
+              String directory = name.substring(0, index + 1);
+              if (!directoriesWritten.contains(directory)) {
                 directoriesWritten.add(directory);
                 outJar.addDirectory(directory);
               }
@@ -514,47 +491,38 @@ public class GuardDB implements ClassConstants
           outJar.addFile(entry.getName(), (byte[]) array[1]);
         }
 
-      }
-      catch (Exception e)
-      {
+      } catch (Exception e) {
         // Log exceptions before exiting
         log.println();
         log.println("<!-- An exception has occured.");
-        if (e instanceof java.util.zip.ZipException){
+        if (e instanceof java.util.zip.ZipException) {
           log.println("This is most likely due to a duplicate .class file in your jar!");
           log.println("Please check that there are no out-of-date or backup duplicate .class files in your jar!");
         }
         log.println(e.toString());
         e.printStackTrace(log);
         log.println("-->");
-        throw new IOException("An error ('"+e.getMessage()+"') occured during the remapping! See the log!)");
-      }
-      finally
-      {
+        throw new IOException("An error ('" + e.getMessage() + "') occured during the remapping! See the log!)");
+      } finally {
         inJar[i].close();
-        if (inStream != null)
-        {
+        if (inStream != null) {
           inStream.close();
         }
-        if (outJar != null)
-        {
+        if (outJar != null) {
           outJar.close();
         }
       }
     }
     // Write the mapping table to the log file
     classTree.dump(log);
-    if(replaceContentsLog.length() > 0 || replaceNameLog.length() > 0)
-    {
+    if (replaceContentsLog.length() > 0 || replaceNameLog.length() > 0) {
       log.println("<!--");
-      if(replaceNameLog.length() > 0)
-      {
+      if (replaceNameLog.length() > 0) {
         log.println("\n<adjust replaceName=\"true\">");
         log.print(replaceNameLog);
         log.println("</adjust>");
       }
-      if(replaceContentsLog.length() > 0)
-      {
+      if (replaceContentsLog.length() > 0) {
         log.println("\n<adjust replaceContents=\"true\">");
         log.print(replaceContentsLog);
         log.println("</adjust>");
@@ -564,7 +532,7 @@ public class GuardDB implements ClassConstants
 
   }
 
-  private DataOutputStream fillDigests(ByteArrayOutputStream baos, String[] digestStrings, MessageDigest[] digests) throws NoSuchAlgorithmException {
+  private DataOutputStream fillDigests( ByteArrayOutputStream baos, String[] digestStrings, MessageDigest[] digests ) throws NoSuchAlgorithmException {
 
     OutputStream stream = baos;
 
@@ -582,12 +550,9 @@ public class GuardDB implements ClassConstants
    *
    * @throws IOException the io exception
    */
-  public void close() throws java.io.IOException
-  {
-    for(int i = 0; i < inJar.length; i++)
-    {
-      if (inJar[i] != null)
-      {
+  public void close() throws java.io.IOException {
+    for (int i = 0; i < inJar.length; i++) {
+      if (inJar[i] != null) {
         inJar[i].close();
         inJar[i] = null;
       }
@@ -595,15 +560,13 @@ public class GuardDB implements ClassConstants
   }
 
   // Parse the RFC822-style MANIFEST.MF file
-  private void parseManifest()throws java.io.IOException
-  {
-    for(int i = 0; i < oldManifest.length; i++)
-    {
+  private void parseManifest() throws java.io.IOException {
+    for (int i = 0; i < oldManifest.length; i++) {
       // The manifest file is the first in the jar and is called
       // (case insensitively) 'MANIFEST.MF'
       oldManifest[i] = inJar[i].getManifest();
 
-      if (oldManifest[i] == null){
+      if (oldManifest[i] == null) {
         oldManifest[i] = new Manifest();
       }
 
@@ -611,7 +574,7 @@ public class GuardDB implements ClassConstants
       newManifest[i] = new Manifest();
 
       // copy all main attributes
-      for (Iterator it = oldManifest[i].getMainAttributes().entrySet().iterator(); it.hasNext();) {
+      for (Iterator it = oldManifest[i].getMainAttributes().entrySet().iterator(); it.hasNext(); ) {
         Map.Entry entry = (Map.Entry) it.next();
         Attributes.Name name = (Attributes.Name) entry.getKey();
         String value = (String) entry.getValue();
@@ -626,19 +589,18 @@ public class GuardDB implements ClassConstants
 
       // copy all directory entries
       for (Iterator it = oldManifest[i].getEntries().entrySet().iterator();
-            it.hasNext();){
-         Map.Entry entry = (Map.Entry) it.next();
-         String name = (String) entry.getKey();
-         if (name.endsWith("/")){
-           newManifest[i].getEntries().put(name, (Attributes) entry.getValue());
-         }
+           it.hasNext(); ) {
+        Map.Entry entry = (Map.Entry) it.next();
+        String name = (String) entry.getKey();
+        if (name.endsWith("/")) {
+          newManifest[i].getEntries().put(name, (Attributes) entry.getValue());
+        }
       }
     }
   }
 
   // Update an entry in the manifest file
-  private void updateManifest(int manifestIndex, String inName, String outName, MessageDigest[] digests)
-  {
+  private void updateManifest( int manifestIndex, String inName, String outName, MessageDigest[] digests ) {
     // Create fresh section for entry, and enter "Name" header
 
     Manifest nm = newManifest[manifestIndex];
@@ -649,28 +611,26 @@ public class GuardDB implements ClassConstants
     //newAtts.putValue(MANIFEST_NAME_TAG, outName);
 
     // copy over non-name and none digest entries
-    if (oldAtts != null){
-      for(Iterator it = oldAtts.entrySet().iterator(); it.hasNext();){
+    if (oldAtts != null) {
+      for (Iterator it = oldAtts.entrySet().iterator(); it.hasNext(); ) {
         Map.Entry entry = (Map.Entry) it.next();
         Object key = entry.getKey();
         String name = key.toString();
         if (!name.equalsIgnoreCase(MANIFEST_NAME_TAG) &&
-            name.indexOf("Digest") == -1){
+            name.indexOf("Digest") == -1) {
           newAtts.remove(name);
-          newAtts.putValue(name, (String)entry.getValue());
+          newAtts.putValue(name, (String) entry.getValue());
         }
       }
     }
 
     // Create fresh digest entries in the new section
-    if (digests != null && digests.length > 0)
-    {
+    if (digests != null && digests.length > 0) {
       // Digest-Algorithms header
       StringBuffer sb = new StringBuffer();
-      for (int i = 0; i < digests.length; i++)
-      {
+      for (int i = 0; i < digests.length; i++) {
         sb.append(digests[i].getAlgorithm());
-        if (i < digests.length -1){
+        if (i < digests.length - 1) {
           sb.append(", ");
         }
       }
@@ -678,8 +638,7 @@ public class GuardDB implements ClassConstants
       newAtts.putValue(MANIFEST_DIGESTALG_TAG, sb.toString());
 
       // *-Digest headers
-      for (int i = 0; i < digests.length; i++)
-      {
+      for (int i = 0; i < digests.length; i++) {
         newAtts.remove(digests[i].getAlgorithm() + "-Digest");
         newAtts.putValue(digests[i].getAlgorithm() + "-Digest", Tools.toBase64(digests[i].digest()));
       }
@@ -692,8 +651,7 @@ public class GuardDB implements ClassConstants
   }
 
   // Create a classfile database.
-  private void buildClassTree(PrintWriter log)throws java.io.IOException
-  {
+  private void buildClassTree( PrintWriter log ) throws java.io.IOException {
     // Go through the input Jar, adding each class file to the database
     classTree = new ClassTree();
     classTree.setPedantic(isPedantic());
@@ -701,55 +659,47 @@ public class GuardDB implements ClassConstants
     ClassFile.resetDangerHeader();
 
     Map parsedClasses = new HashMap();
-    for(int i = 0; i < inJar.length; i++)
-    {
+    for (int i = 0; i < inJar.length; i++) {
       Enumeration entries = inJar[i].getEntries();
       fireParsingJar(inJar[i].getName());
-      while (entries.hasMoreElements())
-      {
+      while (entries.hasMoreElements()) {
         // Get the next entry from the input Jar
-        Entry inEntry = (Entry)entries.nextElement();
+        Entry inEntry = (Entry) entries.nextElement();
         String name = inEntry.getName();
-        if (name.endsWith(CLASS_EXT))
-        {
+        if (name.endsWith(CLASS_EXT)) {
           fireParsingClass(Conversion.toJavaClass(name));
           // Create a full internal representation of the class file
           DataInputStream inStream = new DataInputStream(
-          new BufferedInputStream(
-          inJar[i].getInputStream(inEntry)));
+                  new BufferedInputStream(
+                          inJar[i].getInputStream(inEntry)));
           ClassFile cf = null;
-          try
-          {
+          try {
             cf = ClassFile.create(inStream, isClassVersionChecking());
-          }
-          catch (Exception e)
-          {
+          } catch (Exception e) {
             log.println(ERROR_CORRUPT_CLASS + createJarName(inJar[i], name) + " -->");
             e.printStackTrace(log);
-            throw new ParseException( e );
-          }
-          finally
-          {
+            throw new ParseException(e);
+          } finally {
             inStream.close();
           }
 
-          if (cf != null){
+          if (cf != null) {
             final String cfn = cf.getName();
             final String key = "module-info".equals(cfn)
-              ? createModuleKey(cf) : createClassFileName(name, cf);
+                               ? createModuleKey(cf) : createClassFileName(name, cf);
 
             Object[] old = (Object[]) parsedClasses.get(key);
-            if (old != null){
-              int jarIndex = ((Integer)old[0]).intValue();
+            if (old != null) {
+              int jarIndex = ((Integer) old[0]).intValue();
               String warning = "yGuard detected a duplicate class definition " +
-                "for \n    " + Conversion.toJavaClass(cfn) +
-              "\n    [" + createJarName(inJar[jarIndex], old[1].toString()) + "] in \n    [" +
-                createJarName(inJar[i], name) + "]";
+                               "for \n    " + Conversion.toJavaClass(cfn) +
+                               "\n    [" + createJarName(inJar[jarIndex], old[1].toString()) + "] in \n    [" +
+                               createJarName(inJar[i], name) + "]";
               log.write("<!-- \n" + warning + "\n-->\n");
-              if (jarIndex == i){
+              if (jarIndex == i) {
                 throw new IOException(warning + "\nPlease remove inappropriate duplicates first!");
               } else {
-                if (pedantic){
+                if (pedantic) {
                   throw new IOException(warning + "\nMake sure these files are of the same version!");
                 }
               }
@@ -768,12 +718,9 @@ public class GuardDB implements ClassConstants
 
     // set the java access modifiers from the containing class (muellese)
     final ClassTree ct = classTree;
-    ct.walkTree(new TreeAction()
-    {
-      public void classAction(Cl cl)
-      {
-        if (cl.isInnerClass())
-        {
+    ct.walkTree(new TreeAction() {
+      public void classAction( Cl cl ) {
+        if (cl.isInnerClass()) {
           Cl parent = (Cl) cl.getParent();
           cl.access = parent.getInnerClassModifier(cl.getInName());
         }
@@ -781,12 +728,12 @@ public class GuardDB implements ClassConstants
     });
   }
 
-  private static String createJarName(Archive jar, String name){
-    return "jar:"+jar.getName() + "|" + name;
+  private static String createJarName( Archive jar, String name ) {
+    return "jar:" + jar.getName() + "|" + name;
   }
 
   private static String createClassFileName(
-    final String jarEntryName, final ClassFile cf
+          final String jarEntryName, final ClassFile cf
   ) {
     final String prefix = GuardDB.MULTI_RELEASE_PREFIX;
     if (jarEntryName.startsWith(prefix)) {
@@ -802,8 +749,7 @@ public class GuardDB implements ClassConstants
   }
 
   // Generate a mapping table for obfuscation.
-  private void createMap(PrintWriter log) throws ClassNotFoundException
-  {
+  private void createMap( PrintWriter log ) throws ClassNotFoundException {
     // Traverse the class tree, generating obfuscated names within
     // package and class namespaces
     classTree.generateNames();
@@ -830,10 +776,12 @@ public class GuardDB implements ClassConstants
    *
    * @param jar the jar
    */
-  protected void fireParsingJar(String jar){
-    if (listenerList == null) return;
-    for (int i = 0, j = listenerList.size(); i < j; i++){
-      ((ObfuscationListener)listenerList.get(i)).parsingJar(jar);
+  protected void fireParsingJar( String jar ) {
+    if (listenerList == null) {
+      return;
+    }
+    for (int i = 0, j = listenerList.size(); i < j; i++) {
+      ((ObfuscationListener) listenerList.get(i)).parsingJar(jar);
     }
   }
 
@@ -842,10 +790,12 @@ public class GuardDB implements ClassConstants
    *
    * @param className the class name
    */
-  protected void fireParsingClass(String className){
-    if (listenerList == null) return;
-    for (int i = 0, j = listenerList.size(); i < j; i++){
-      ((ObfuscationListener)listenerList.get(i)).parsingClass(className);
+  protected void fireParsingClass( String className ) {
+    if (listenerList == null) {
+      return;
+    }
+    for (int i = 0, j = listenerList.size(); i < j; i++) {
+      ((ObfuscationListener) listenerList.get(i)).parsingClass(className);
     }
   }
 
@@ -855,10 +805,12 @@ public class GuardDB implements ClassConstants
    * @param inJar  the in jar
    * @param outJar the out jar
    */
-  protected void fireObfuscatingJar(String inJar, String outJar){
-    if (listenerList == null) return;
-    for (int i = 0, j = listenerList.size(); i < j; i++){
-      ((ObfuscationListener)listenerList.get(i)).obfuscatingJar(inJar, outJar);
+  protected void fireObfuscatingJar( String inJar, String outJar ) {
+    if (listenerList == null) {
+      return;
+    }
+    for (int i = 0, j = listenerList.size(); i < j; i++) {
+      ((ObfuscationListener) listenerList.get(i)).obfuscatingJar(inJar, outJar);
     }
   }
 
@@ -867,10 +819,12 @@ public class GuardDB implements ClassConstants
    *
    * @param className the class name
    */
-  protected void fireObfuscatingClass(String className){
-    if (listenerList == null) return;
-    for (int i = 0, j = listenerList.size(); i < j; i++){
-      ((ObfuscationListener)listenerList.get(i)).obfuscatingClass(className);
+  protected void fireObfuscatingClass( String className ) {
+    if (listenerList == null) {
+      return;
+    }
+    for (int i = 0, j = listenerList.size(); i < j; i++) {
+      ((ObfuscationListener) listenerList.get(i)).obfuscatingClass(className);
     }
   }
 
@@ -879,10 +833,8 @@ public class GuardDB implements ClassConstants
    *
    * @param listener The listener to register.
    */
-  public synchronized void addListener(com.yworks.yguard.ObfuscationListener listener)
-  {
-    if (listenerList == null )
-    {
+  public synchronized void addListener( com.yworks.yguard.ObfuscationListener listener ) {
+    if (listenerList == null) {
       listenerList = new java.util.ArrayList();
     }
     listenerList.add(listener);
@@ -893,10 +845,8 @@ public class GuardDB implements ClassConstants
    *
    * @param listener The listener to remove.
    */
-  public synchronized void removeListener(com.yworks.yguard.ObfuscationListener listener)
-  {
-    if (listenerList != null )
-    {
+  public synchronized void removeListener( com.yworks.yguard.ObfuscationListener listener ) {
+    if (listenerList != null) {
       listenerList.remove(listener);
     }
   }
@@ -906,8 +856,7 @@ public class GuardDB implements ClassConstants
    *
    * @return Value of property replaceClassNameStrings.
    */
-  public boolean isReplaceClassNameStrings()
-  {
+  public boolean isReplaceClassNameStrings() {
     return this.replaceClassNameStrings;
   }
 
@@ -916,8 +865,7 @@ public class GuardDB implements ClassConstants
    *
    * @param replaceClassNameStrings New value of property replaceClassNameStrings.
    */
-  public void setReplaceClassNameStrings(boolean replaceClassNameStrings)
-  {
+  public void setReplaceClassNameStrings( boolean replaceClassNameStrings ) {
     this.replaceClassNameStrings = replaceClassNameStrings;
   }
 
@@ -927,8 +875,7 @@ public class GuardDB implements ClassConstants
    *
    * @return Value of property pedantic.
    */
-  public boolean isPedantic()
-  {
+  public boolean isPedantic() {
     return this.pedantic;
   }
 
@@ -937,8 +884,7 @@ public class GuardDB implements ClassConstants
    *
    * @param pedantic New value of property pedantic.
    */
-  public void setPedantic(boolean pedantic)
-  {
+  public void setPedantic( boolean pedantic ) {
     this.pedantic = pedantic;
     Cl.setPedantic(pedantic);
   }
@@ -958,15 +904,11 @@ public class GuardDB implements ClassConstants
    * @param javaClass the fully qualified name of an unobfuscated class.
    * @return the string
    */
-  public String translateJavaFile(String javaClass)
-  {
-    Cl cl = classTree.findClassForName(javaClass.replace('/','.'));
-    if(cl != null)
-    {
+  public String translateJavaFile( String javaClass ) {
+    Cl cl = classTree.findClassForName(javaClass.replace('/', '.'));
+    if (cl != null) {
       return cl.getFullOutName();
-    }
-    else
-    {
+    } else {
       return javaClass;
     }
   }
@@ -978,28 +920,25 @@ public class GuardDB implements ClassConstants
    * @param javaClass the java class
    * @return the string
    */
-  public String translateJavaClass(String javaClass)
-  {
+  public String translateJavaClass( String javaClass ) {
     Cl cl = classTree.findClassForName(javaClass);
-    if(cl != null)
-    {
+    if (cl != null) {
       return cl.getFullOutName().replace('/', '.');
-    }
-    else
-    {
+    } else {
       return javaClass;
     }
   }
 
   /**
    * Translates the given class or package identifier.
+   *
    * @param identifier a qualified class name or a jar entry name.
-   * @param strict if <code>true</code>, translate the whole identifier only;
-   * otherwise translate as much of the given identifier as possible.
+   * @param strict     if <code>true</code>, translate the whole identifier only;
+   *                   otherwise translate as much of the given identifier as possible.
    * @return the mapped identifier.
    */
   public String translateItem(
-    final String identifier, final char seperator, final boolean strict
+          final String identifier, final char seperator, final boolean strict
   ) {
     final int n = identifier.length();
     final int lios = identifier.lastIndexOf(seperator);
@@ -1014,7 +953,7 @@ public class GuardDB implements ClassConstants
     String sep = lios > -1 ? Character.toString(seperator) : nested;
     boolean nestedItem = false;
     for (StringTokenizer st = new StringTokenizer(identifier, sep);
-         st.hasMoreTokens();) {
+         st.hasMoreTokens(); ) {
       final String t;
       if (offset == lios) {
         sep = nested;
@@ -1060,8 +999,8 @@ public class GuardDB implements ClassConstants
     // in strict mode, only qualified class names may be translated but not
     // package names
     return strict && !nestedItem
-      ? identifier
-      : sb.toString();
+           ? identifier
+           : sb.toString();
   }
 
   /**
@@ -1069,7 +1008,7 @@ public class GuardDB implements ClassConstants
    *
    * @param digestStrings the digest strings
    */
-  public void setDigests(String[] digestStrings) {
+  public void setDigests( String[] digestStrings ) {
     this.digestStrings = digestStrings;
   }
 
@@ -1078,7 +1017,7 @@ public class GuardDB implements ClassConstants
    *
    * @param annotationClass the annotation class
    */
-  public void setAnnotationClass(String annotationClass) {
+  public void setAnnotationClass( String annotationClass ) {
     ObfuscationConfig.annotationClassName = annotationClass;
   }
 }

--- a/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
+++ b/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
@@ -34,1699 +34,1577 @@ import java.util.Vector;
  *
  * @author Mark Welsh
  */
-public class ClassFile implements ClassConstants
-{
-    // Constants -------------------------------------------------------------
-    /**
-     * The constant SEP_REGULAR.
-     */
-    public static final String SEP_REGULAR = "/";
-    /**
-     * The constant SEP_INNER.
-     */
-    public static final String SEP_INNER = "$";
-    /**
-     * The constant LOG_DANGER_HEADER1.
-     */
-    public static final String LOG_DANGER_HEADER1 = "Methods are called which may break in obfuscated version at runtime.";
-    /**
-     * The constant LOG_DANGER_HEADER2.
-     */
-    public static final String LOG_DANGER_HEADER2 = "Please review your source code to ensure that the dangerous methods are not intended";
-    /**
-     * The constant LOG_DANGER_HEADER3.
-     */
-    public static final String LOG_DANGER_HEADER3 = "to act on classes which have been obfuscated.";
-    private static final String[] SEMI_DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY = {
-        "forName(Ljava/lang/String;)Ljava/lang/Class;",
-        "forName(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
-    };
-    private static final String[] DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY = {
-        "forName(Ljava/lang/String;)Ljava/lang/Class;",
-        "forName(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
-        "getDeclaredField(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-        "getField(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-        "getDeclaredMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
-        "getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;"
-    };
-    private static final String LOG_DANGER_CLASS_PRE = "    Your class ";
-    private static final String LOG_DANGER_CLASS_MID = " calls the java.lang.Class method ";
-    private static final String[] DANGEROUS_CLASSLOADER_SIMPLENAME_DESCRIPTOR_ARRAY = {
-        "defineClass(Ljava/lang/String;[BII)Ljava/lang/Class;",
-        "findLoadedClass(Ljava/lang/String;)Ljava/lang/Class;",
-        "findSystemClass(Ljava/lang/String;)Ljava/lang/Class;",
-        "loadClass(Ljava/lang/String;)Ljava/lang/Class;",
-        "loadClass(Ljava/lang/String;Z)Ljava/lang/Class;"
-    };
-    private static final String LOG_DANGER_CLASSLOADER_PRE = "    Your class ";
-    private static final String LOG_DANGER_CLASSLOADER_MID = " calls the java.lang.ClassLoader method ";
+public class ClassFile implements ClassConstants {
+  // Constants -------------------------------------------------------------
+  /**
+   * The constant SEP_REGULAR.
+   */
+  public static final String SEP_REGULAR = "/";
+  /**
+   * The constant SEP_INNER.
+   */
+  public static final String SEP_INNER = "$";
+  /**
+   * The constant LOG_DANGER_HEADER1.
+   */
+  public static final String LOG_DANGER_HEADER1 = "Methods are called which may break in obfuscated version at runtime.";
+  /**
+   * The constant LOG_DANGER_HEADER2.
+   */
+  public static final String LOG_DANGER_HEADER2 = "Please review your source code to ensure that the dangerous methods are not intended";
+  /**
+   * The constant LOG_DANGER_HEADER3.
+   */
+  public static final String LOG_DANGER_HEADER3 = "to act on classes which have been obfuscated.";
+  private static final String[] SEMI_DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY = {
+          "forName(Ljava/lang/String;)Ljava/lang/Class;",
+          "forName(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
+          };
+  private static final String[] DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY = {
+          "forName(Ljava/lang/String;)Ljava/lang/Class;",
+          "forName(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
+          "getDeclaredField(Ljava/lang/String;)Ljava/lang/reflect/Field;",
+          "getField(Ljava/lang/String;)Ljava/lang/reflect/Field;",
+          "getDeclaredMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
+          "getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;"
+  };
+  private static final String LOG_DANGER_CLASS_PRE = "    Your class ";
+  private static final String LOG_DANGER_CLASS_MID = " calls the java.lang.Class method ";
+  private static final String[] DANGEROUS_CLASSLOADER_SIMPLENAME_DESCRIPTOR_ARRAY = {
+          "defineClass(Ljava/lang/String;[BII)Ljava/lang/Class;",
+          "findLoadedClass(Ljava/lang/String;)Ljava/lang/Class;",
+          "findSystemClass(Ljava/lang/String;)Ljava/lang/Class;",
+          "loadClass(Ljava/lang/String;)Ljava/lang/Class;",
+          "loadClass(Ljava/lang/String;Z)Ljava/lang/Class;"
+  };
+  private static final String LOG_DANGER_CLASSLOADER_PRE = "    Your class ";
+  private static final String LOG_DANGER_CLASSLOADER_MID = " calls the java.lang.ClassLoader method ";
 
-    /**
-     * {@link java.lang.runtime.ObjectMethods} method.
-     */
-    private static final int BM_TYPE_OM = 3;
-    /**
-     * {@link java.lang.invoke.StringConcatFactory} method.
-     */
-    private static final int BM_TYPE_SCF = 2;
-    /**
-     * {@link java.lang.invoke.LambdaMetafactory} method.
-     */
-    private static final int BM_TYPE_LMF = 1;
-    /**
-     * Unknown bootstrap method, throw exception.
-     */
-    private static final int BM_TYPE_UNKNOWN = 0;
+  /**
+   * {@link java.lang.runtime.ObjectMethods} method.
+   */
+  private static final int BM_TYPE_OM = 3;
+  /**
+   * {@link java.lang.invoke.StringConcatFactory} method.
+   */
+  private static final int BM_TYPE_SCF = 2;
+  /**
+   * {@link java.lang.invoke.LambdaMetafactory} method.
+   */
+  private static final int BM_TYPE_LMF = 1;
+  /**
+   * Unknown bootstrap method, throw exception.
+   */
+  private static final int BM_TYPE_UNKNOWN = 0;
 
-    // Fields ----------------------------------------------------------------
-    private int u4magic;
-    private int u2minorVersion;
-    private int u2majorVersion;
-    private ConstantPool constantPool;
-    private int u2accessFlags;
-    private int u2thisClass;
-    private int u2superClass;
-    private int u2interfacesCount;
-    private int u2interfaces[];
-    private int u2fieldsCount;
-    private FieldInfo fields[];
-    private int u2methodsCount;
-    private MethodInfo methods[];
-    private int u2attributesCount;
-    private AttrInfo attributes[];
+  // Fields ----------------------------------------------------------------
+  private int u4magic;
+  private int u2minorVersion;
+  private int u2majorVersion;
+  private ConstantPool constantPool;
+  private int u2accessFlags;
+  private int u2thisClass;
+  private int u2superClass;
+  private int u2interfacesCount;
+  private int u2interfaces[];
+  private int u2fieldsCount;
+  private FieldInfo fields[];
+  private int u2methodsCount;
+  private MethodInfo methods[];
+  private int u2attributesCount;
+  private AttrInfo attributes[];
 
-    private boolean isUnkAttrGone = false;
+  private boolean isUnkAttrGone = false;
 
-    private static boolean writeIdString = false;
-    private static CpInfo cpIdString = null;
+  private static boolean writeIdString = false;
+  private static CpInfo cpIdString = null;
 
 
-    // Class Methods ---------------------------------------------------------
+  // Class Methods ---------------------------------------------------------
 
-    /**
-     * Define a constant String to include in every output class file.
-     *
-     * @param id the id
-     */
-    public static void defineIdString(String id)
-    {
-        if (id != null) {
-            writeIdString = true;
-            cpIdString = new Utf8CpInfo(id);
-        } else {
-            writeIdString = false;
-            cpIdString = null;
-        }
+  /**
+   * Define a constant String to include in every output class file.
+   *
+   * @param id the id
+   */
+  public static void defineIdString( String id ) {
+    if (id != null) {
+      writeIdString = true;
+      cpIdString = new Utf8CpInfo(id);
+    } else {
+      writeIdString = false;
+      cpIdString = null;
     }
+  }
 
-    /**
-     * Create a new ClassFile from the class file format data in the DataInput
-     * stream.
-     *
-     * @param din the din
-     * @param classVersionChecking check or not class file version (default true)
-     * @return the class file
-     * @throws IOException if class file is corrupt or incomplete
-     */
-    public static ClassFile create(DataInput din, boolean classVersionChecking) throws IOException
-    {
-        if (din == null) throw new NullPointerException("No input stream was provided.");
-        ClassFile cf = new ClassFile();
-        cf.read(din, classVersionChecking);
-        return cf;
+  /**
+   * Create a new ClassFile from the class file format data in the DataInput
+   * stream.
+   *
+   * @param din                  the din
+   * @param classVersionChecking check or not class file version (default true)
+   * @return the class file
+   * @throws IOException if class file is corrupt or incomplete
+   */
+  public static ClassFile create( DataInput din, boolean classVersionChecking ) throws IOException {
+    if (din == null) {
+      throw new NullPointerException("No input stream was provided.");
     }
+    ClassFile cf = new ClassFile();
+    cf.read(din, classVersionChecking);
+    return cf;
+  }
 
-    /**
-     * Parse a method or field descriptor into a list of parameter names (for methods)
-     * and a return type, in same format as the Class.forName() method returns .
-     *
-     * @param descriptor the descriptor
-     * @return the string [ ]
-     */
-    public static String[] parseDescriptor(String descriptor)
-    {
-        return parseDescriptor(descriptor, false);
-    }
+  /**
+   * Parse a method or field descriptor into a list of parameter names (for methods)
+   * and a return type, in same format as the Class.forName() method returns .
+   *
+   * @param descriptor the descriptor
+   * @return the string [ ]
+   */
+  public static String[] parseDescriptor( String descriptor ) {
+    return parseDescriptor(descriptor, false);
+  }
 
-    /**
-     * Parse a method or field descriptor into a list of parameter names (for methods)
-     * and a return type, in same format as the Class.forName() method returns .
-     *
-     * @param descriptor the descriptor
-     * @param isDisplay  the is display
-     * @return the string [ ]
-     */
-    public static String[] parseDescriptor(String descriptor, boolean isDisplay)
-    {
-        // Check for field descriptor
-        String[] names = null;
-        if (descriptor.charAt(0) != '(')
-        {
-            names = new String[1];
-            names[0] = descriptor;
-        }
-        else
-        {
-            // Method descriptor
-            Vector namesVec = new Vector();
+  /**
+   * Parse a method or field descriptor into a list of parameter names (for methods)
+   * and a return type, in same format as the Class.forName() method returns .
+   *
+   * @param descriptor the descriptor
+   * @param isDisplay  the is display
+   * @return the string [ ]
+   */
+  public static String[] parseDescriptor( String descriptor, boolean isDisplay ) {
+    // Check for field descriptor
+    String[] names = null;
+    if (descriptor.charAt(0) != '(') {
+      names = new String[1];
+      names[0] = descriptor;
+    } else {
+      // Method descriptor
+      Vector namesVec = new Vector();
+      descriptor = descriptor.substring(1);
+      String type = "";
+      while (descriptor.length() > 0) {
+        switch (descriptor.charAt(0)) {
+          case '[':
+            type = type + "[";
             descriptor = descriptor.substring(1);
-            String type = "";
-            while (descriptor.length() > 0)
-            {
-                switch (descriptor.charAt(0))
-                {
-                case '[':
-                    type = type + "[";
-                    descriptor = descriptor.substring(1);
-                    break;
-
-                case 'B':
-                case 'C':
-                case 'D':
-                case 'F':
-                case 'I':
-                case 'J':
-                case 'S':
-                case 'Z':
-                case 'V':
-                    namesVec.addElement(type + descriptor.substring(0, 1));
-                    descriptor = descriptor.substring(1);
-                    type = "";
-                    break;
-
-                case ')':
-                    descriptor = descriptor.substring(1);
-                    break;
-
-                case 'L':
-                    {
-                        int pos = descriptor.indexOf(';') + 1;
-                        namesVec.addElement(type + descriptor.substring(0, pos));
-                        descriptor = descriptor.substring(pos);
-                        type = "";
-                    }
-                    break;
-
-                default:
-                    throw new IllegalArgumentException("Illegal field or method descriptor: " + descriptor);
-                }
-            }
-            names = new String[namesVec.size()];
-            for (int i = 0; i < names.length; i++)
-            {
-                names[i] = (String)namesVec.elementAt(i);
-            }
-        }
-
-        // Translate the names from JVM to Class.forName() format.
-        String[] translatedNames = new String[names.length];
-        for (int i = 0; i < names.length; i++)
-        {
-            translatedNames[i] = translateType(names[i], isDisplay);
-        }
-        return translatedNames;
-    }
-
-    /**
-     * Translate a type specifier from the internal JVM convention to the Class.forName() one.
-     *
-     * @param inName    the in name
-     * @param isDisplay the is display
-     * @return the string
-     */
-    public static String translateType(String inName, boolean isDisplay)
-    {
-        String outName = null;
-        switch (inName.charAt(0))
-        {
-        case '[': // For array types, Class.forName() inconsistently uses the internal type name
-                  // but with '/' --> '.'
-            if (!isDisplay)
-            {
-                // return the Class.forName() form
-                outName = translate(inName);
-            }
-            else
-            {
-                // return the pretty display form
-                outName = translateType(inName.substring(1), true) + "[]";
-            }
             break;
 
-        case 'B':
-            outName = Byte.TYPE.getName();
+          case 'B':
+          case 'C':
+          case 'D':
+          case 'F':
+          case 'I':
+          case 'J':
+          case 'S':
+          case 'Z':
+          case 'V':
+            namesVec.addElement(type + descriptor.substring(0, 1));
+            descriptor = descriptor.substring(1);
+            type = "";
             break;
 
-        case 'C':
-            outName = Character.TYPE.getName();
+          case ')':
+            descriptor = descriptor.substring(1);
             break;
 
-        case 'D':
-            outName = Double.TYPE.getName();
-            break;
+          case 'L': {
+            int pos = descriptor.indexOf(';') + 1;
+            namesVec.addElement(type + descriptor.substring(0, pos));
+            descriptor = descriptor.substring(pos);
+            type = "";
+          }
+          break;
 
-        case 'F':
-            outName = Float.TYPE.getName();
-            break;
+          default:
+            throw new IllegalArgumentException("Illegal field or method descriptor: " + descriptor);
+        }
+      }
+      names = new String[namesVec.size()];
+      for (int i = 0; i < names.length; i++) {
+        names[i] = (String) namesVec.elementAt(i);
+      }
+    }
 
-        case 'I':
-            outName = Integer.TYPE.getName();
-            break;
+    // Translate the names from JVM to Class.forName() format.
+    String[] translatedNames = new String[names.length];
+    for (int i = 0; i < names.length; i++) {
+      translatedNames[i] = translateType(names[i], isDisplay);
+    }
+    return translatedNames;
+  }
 
-        case 'J':
-            outName = Long.TYPE.getName();
-            break;
+  /**
+   * Translate a type specifier from the internal JVM convention to the Class.forName() one.
+   *
+   * @param inName    the in name
+   * @param isDisplay the is display
+   * @return the string
+   */
+  public static String translateType( String inName, boolean isDisplay ) {
+    String outName = null;
+    switch (inName.charAt(0)) {
+      case '[': // For array types, Class.forName() inconsistently uses the internal type name
+        // but with '/' --> '.'
+        if (!isDisplay) {
+          // return the Class.forName() form
+          outName = translate(inName);
+        } else {
+          // return the pretty display form
+          outName = translateType(inName.substring(1), true) + "[]";
+        }
+        break;
 
-        case 'S':
-            outName = Short.TYPE.getName();
-            break;
+      case 'B':
+        outName = Byte.TYPE.getName();
+        break;
 
-        case 'Z':
-            outName = Boolean.TYPE.getName();
-            break;
+      case 'C':
+        outName = Character.TYPE.getName();
+        break;
 
-        case 'V':
-            outName = Void.TYPE.getName();
-            break;
+      case 'D':
+        outName = Double.TYPE.getName();
+        break;
 
-        case 'L':
-            {
-                int pos = inName.indexOf(';');
-                outName = translate(inName.substring(1, inName.indexOf(';')));
+      case 'F':
+        outName = Float.TYPE.getName();
+        break;
+
+      case 'I':
+        outName = Integer.TYPE.getName();
+        break;
+
+      case 'J':
+        outName = Long.TYPE.getName();
+        break;
+
+      case 'S':
+        outName = Short.TYPE.getName();
+        break;
+
+      case 'Z':
+        outName = Boolean.TYPE.getName();
+        break;
+
+      case 'V':
+        outName = Void.TYPE.getName();
+        break;
+
+      case 'L': {
+        int pos = inName.indexOf(';');
+        outName = translate(inName.substring(1, inName.indexOf(';')));
+      }
+      break;
+
+      default:
+        throw new IllegalArgumentException("Illegal field or method name: " + inName);
+    }
+    return outName;
+  }
+
+  /**
+   * Translate a class name from the internal '/' convention to the regular '.' one.
+   *
+   * @param name the name
+   * @return the string
+   */
+  public static String translate( String name ) {
+    return name.replace('/', '.');
+  }
+
+
+  // Instance Methods ------------------------------------------------------
+  // Private constructor.
+  private ClassFile() {
+  }
+
+  // Import the class data to internal representation.
+  private void read( DataInput din, boolean classVersionChecking ) throws IOException {
+    // Read the class file
+    u4magic = din.readInt();
+    u2minorVersion = din.readUnsignedShort();
+    u2majorVersion = din.readUnsignedShort();
+
+    // Check this is a valid classfile that we can handle
+    if (u4magic != MAGIC) {
+      throw new IOException("Invalid magic number in class file.");
+    }
+    if (u2majorVersion > MAJOR_VERSION) {
+      if (classVersionChecking) {
+        throw new IOException("Incompatible version number for class file format: " + u2majorVersion + "." + u2minorVersion);
+      } else {
+        Logger.getInstance().warning("Incompatible version number for class file format: " + u2majorVersion + "." + u2minorVersion);
+      }
+    }
+
+
+    int u2constantPoolCount = din.readUnsignedShort();
+    CpInfo[] cpInfo = new CpInfo[u2constantPoolCount];
+    // Fill the constant pool, recalling the zero entry
+    // is not persisted, nor are the entries following a Long or Double
+    for (int i = 1; i < u2constantPoolCount; i++) {
+      cpInfo[i] = CpInfo.create(din);
+      if ((cpInfo[i] instanceof LongCpInfo) ||
+          (cpInfo[i] instanceof DoubleCpInfo)) {
+        i++;
+      }
+      // todo: remove once remapping CONSTANT_Dynamic_info is supported
+      else if (cpInfo[i] instanceof DynamicCpInfo) {
+        throw new IOException("Unsupported tag type in constant pool: dynamic");
+      }
+    }
+    constantPool = new ConstantPool(this, cpInfo);
+
+    u2accessFlags = din.readUnsignedShort();
+    u2thisClass = din.readUnsignedShort();
+    u2superClass = din.readUnsignedShort();
+    u2interfacesCount = din.readUnsignedShort();
+    u2interfaces = new int[u2interfacesCount];
+    for (int i = 0; i < u2interfacesCount; i++) {
+      u2interfaces[i] = din.readUnsignedShort();
+    }
+    u2fieldsCount = din.readUnsignedShort();
+    fields = new FieldInfo[u2fieldsCount];
+    for (int i = 0; i < u2fieldsCount; i++) {
+      fields[i] = FieldInfo.create(din, this);
+    }
+    u2methodsCount = din.readUnsignedShort();
+    methods = new MethodInfo[u2methodsCount];
+    for (int i = 0; i < u2methodsCount; i++) {
+      methods[i] = MethodInfo.create(din, this);
+    }
+    u2attributesCount = din.readUnsignedShort();
+    attributes = new AttrInfo[u2attributesCount];
+    for (int i = 0; i < u2attributesCount; i++) {
+      attributes[i] = AttrInfo.create(din, this);
+    }
+  }
+
+  /**
+   * Get class file access int.
+   *
+   * @return the int
+   */
+  public int getClassFileAccess() {
+    return u2accessFlags;
+  }
+
+  /**
+   * Get modifiers int.
+   *
+   * @return the int
+   */
+  public int getModifiers() {
+    int mods = 0;
+    if ((u2accessFlags & 0x0001) == 0x0001) {
+      mods |= Modifier.PUBLIC;
+    }
+    if ((u2accessFlags & 0x0010) == 0x0010) {
+      mods |= Modifier.FINAL;
+    }
+    if ((u2accessFlags & 0x0200) == 0x0200) {
+      mods |= Modifier.INTERFACE;
+    }
+    if ((u2accessFlags & 0x0400) == 0x0400) {
+      mods |= Modifier.ABSTRACT;
+    }
+    return mods;
+  }
+
+  /**
+   * Return the name of this classfile.
+   *
+   * @return the name
+   */
+  public String getName() {
+    return toName(u2thisClass);
+  }
+
+  /**
+   * Return the name of this class's superclass.
+   *
+   * @return the super
+   */
+  public String getSuper() {
+    // This may be java/lang/Object, in which case there is no super
+    return (u2superClass == 0) ? null : toName(u2superClass);
+  }
+
+  /**
+   * Return the names of this class's interfaces.
+   *
+   * @return the string [ ]
+   */
+  public String[] getInterfaces() {
+    String[] interfaces = new String[u2interfacesCount];
+    for (int i = 0; i < u2interfacesCount; i++) {
+      interfaces[i] = toName(u2interfaces[i]);
+    }
+    return interfaces;
+  }
+
+  // Convert a CP index to a class name.
+  private String toName( int u2index ) {
+    CpInfo classEntry = getCpEntry(u2index);
+    if (classEntry instanceof ClassCpInfo) {
+      CpInfo nameEntry = getCpEntry(((ClassCpInfo) classEntry).getNameIndex());
+      if (nameEntry instanceof Utf8CpInfo) {
+        return ((Utf8CpInfo) nameEntry).getString();
+      } else {
+        throw new ParseException("Inconsistent Constant Pool in class file.");
+      }
+    } else {
+      throw new ParseException("Inconsistent Constant Pool in class file.");
+    }
+  }
+
+  /**
+   * Return an enumeration of method name/descriptor pairs.
+   *
+   * @return the method enum
+   */
+  public Enumeration getMethodEnum() {
+    Vector vec = new Vector();
+    for (int i = 0; i < methods.length; i++) {
+      vec.addElement(methods[i]);
+    }
+    return vec.elements();
+  }
+
+  /**
+   * Return an enumeration of field name/descriptor pairs.
+   *
+   * @return the field enum
+   */
+  public Enumeration getFieldEnum() {
+    Vector vec = new Vector();
+    for (int i = 0; i < fields.length; i++) {
+      vec.addElement(fields[i]);
+    }
+    return vec.elements();
+  }
+
+  /**
+   * Lookup the entry in the constant pool and return as an Object.
+   *
+   * @param cpIndex the cp index
+   * @return the cp entry
+   */
+  public CpInfo getCpEntry( int cpIndex ) {
+    return constantPool.getCpEntry(cpIndex);
+  }
+
+  private String getUtf8( int cpIndex ) {
+    return ((Utf8CpInfo) getCpEntry(cpIndex)).getString();
+  }
+
+  /**
+   * Gets constant pool.
+   *
+   * @return the constant pool
+   */
+  public ConstantPool getConstantPool() {
+    return constantPool;
+  }
+
+  /**
+   * Check for methods which can break the obfuscated code, and log them to a String[].
+   *
+   * @param replaceClassNameStrings the replace class name strings
+   * @return the string [ ]
+   */
+  public String[] logDangerousMethods( boolean replaceClassNameStrings ) {
+    Vector warningVec = new Vector();
+
+    // Need only check CONSTANT_Methodref entries of constant pool since
+    // dangerous methods belong to classes 'Class' and 'ClassLoader', not to interfaces.
+    for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); ) {
+      Object o = enumeration.nextElement();
+      if (o instanceof MethodrefCpInfo) {
+        // Get the method class name, simple name and descriptor
+        MethodrefCpInfo entry = (MethodrefCpInfo) o;
+        ClassCpInfo classEntry = (ClassCpInfo) getCpEntry(entry.getClassIndex());
+        String className = ((Utf8CpInfo) getCpEntry(classEntry.getNameIndex())).getString();
+        NameAndTypeCpInfo ntEntry = (NameAndTypeCpInfo) getCpEntry(entry.getNameAndTypeIndex());
+        String name = ((Utf8CpInfo) getCpEntry(ntEntry.getNameIndex())).getString();
+        String descriptor = ((Utf8CpInfo) getCpEntry(ntEntry.getDescriptorIndex())).getString();
+
+        // Check if this is on the proscribed list
+        if (className.equals("java/lang/Class") &&
+            Tools.isInArray(name + descriptor, DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY)) {
+          if (replaceClassNameStrings) {
+            if (!Tools.isInArray(name + descriptor, SEMI_DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY)) {
+              String jMethod = Conversion.toJavaMethod(name, descriptor);
+              warningVec.addElement(LOG_DANGER_CLASS_PRE + Conversion.toJavaClass(getName()) + LOG_DANGER_CLASS_MID + jMethod);
             }
-            break;
-
-        default:
-            throw new IllegalArgumentException("Illegal field or method name: " + inName);
+          }
+        } else if (Tools.isInArray(name + descriptor, DANGEROUS_CLASSLOADER_SIMPLENAME_DESCRIPTOR_ARRAY)) {
+          String jMethod = Conversion.toJavaMethod(name, descriptor);
+          warningVec.addElement(LOG_DANGER_CLASSLOADER_PRE + Conversion.toJavaClass(getName()) + LOG_DANGER_CLASSLOADER_MID + jMethod);
+        } else if ("class$(Ljava/lang/String;)Ljava/lang/Class;".equals(name + descriptor)) {
+          if (!replaceClassNameStrings) {
+            warningVec.addElement(LOG_DANGER_CLASS_PRE + Conversion.toJavaClass(getName()) + " seems to be using the '.class' construct!");
+          }
         }
-        return outName;
+      }
     }
 
-    /**
-     * Translate a class name from the internal '/' convention to the regular '.' one.
-     *
-     * @param name the name
-     * @return the string
-     */
-    public static String translate(String name)
-    {
-        return name.replace('/', '.');
+    // Copy any warnings to a String[]
+    String[] warnings = new String[warningVec.size()];
+    for (int i = 0; i < warnings.length; i++) {
+      warnings[i] = (String) warningVec.elementAt(i);
+    }
+    return warnings;
+  }
+
+  /**
+   * Check for methods which can break the obfuscated code, and log them.
+   */
+  private static boolean hasHeader = false;
+
+  /**
+   * Reset danger header.
+   */
+  public static void resetDangerHeader() {
+    hasHeader = false;
+  }
+
+  /**
+   * Log dangerous methods.
+   *
+   * @param log                     the log
+   * @param replaceClassNameStrings the replace class name strings
+   */
+  public void logDangerousMethods( PrintWriter log, boolean replaceClassNameStrings ) {
+    // Get any warnings and print them to the logfile
+    String[] warnings = logDangerousMethods(replaceClassNameStrings);
+    if (warnings != null && warnings.length > 0) {
+      if (!hasHeader) {
+        log.println("<!-- WARNING");
+        log.println(LOG_DANGER_HEADER1);
+        log.println(LOG_DANGER_HEADER2);
+        log.println(LOG_DANGER_HEADER3);
+
+        Logger logger = Logger.getInstance();
+        logger.warning(LOG_DANGER_HEADER1 + '\n' +
+                       LOG_DANGER_HEADER2 + '\n' +
+                       LOG_DANGER_HEADER3 + '\n' +
+                       "See the logfile for a list of these classes and methods.");
+
+        log.println("-->");
+        hasHeader = true;
+      }
+      if (warnings.length > 0) {
+        log.println("<!--");
+        for (int i = 0; i < warnings.length; i++) {
+          log.println(" " + warnings[i]);
+        }
+        log.println("-->");
+      }
+    }
+  }
+
+  /**
+   * Check for direct references to Utf8 constant pool entries.
+   *
+   * @param pool the pool
+   */
+  public void markUtf8Refs( ConstantPool pool ) {
+    try {
+      // Check for references to Utf8 from outside the constant pool
+      for (int i = 0; i < fields.length; i++) {
+        fields[i].markUtf8Refs(pool);
+      }
+      for (int i = 0; i < methods.length; i++) {
+        methods[i].markUtf8Refs(pool); // also checks Code/LVT attrs here
+      }
+      for (int i = 0; i < attributes.length; i++) {
+        attributes[i].markUtf8Refs(pool); // checks InnerClasses, SourceFile and all attr names
+      }
+
+      // Now check for references from other CP entries
+      for (Enumeration enumeration = pool.elements(); enumeration.hasMoreElements(); ) {
+        Object o = enumeration.nextElement();
+        if (o instanceof NameAndTypeCpInfo ||
+            o instanceof AbstractTypeCpInfo ||
+            o instanceof MethodTypeCpInfo ||
+            o instanceof StringCpInfo) {
+          ((CpInfo) o).markUtf8Refs(pool);
+        }
+      }
+    } catch (ArrayIndexOutOfBoundsException e) {
+      throw new ParseException("Inconsistent reference to constant pool.");
+    }
+  }
+
+  /**
+   * Check for direct references to NameAndType constant pool entries.
+   *
+   * @param pool the pool
+   */
+  public void markNTRefs( ConstantPool pool ) {
+    try {
+      // Now check the method and field CP entries
+      for (Enumeration enumeration = pool.elements(); enumeration.hasMoreElements(); ) {
+        Object o = enumeration.nextElement();
+        if (o instanceof RefCpInfo ||
+            o instanceof AbstractDynamicCpInfo) {
+          ((CpInfo) o).markNTRefs(pool);
+        }
+      }
+    } catch (ArrayIndexOutOfBoundsException e) {
+      throw new ParseException("Inconsistent reference to constant pool.");
+    }
+  }
+
+  /**
+   * Trim attributes from the classfile ('Code', 'Exceptions', 'ConstantValue'
+   * are preserved, all others except the list in the String[] are killed).
+   *
+   * @param extraAttrs the extra attrs
+   */
+  public void trimAttrsExcept( String[] extraAttrs ) {
+    // Merge additional attributes with required list
+    String[] keepAttrs = REQUIRED_ATTRS;
+    if (extraAttrs != null && extraAttrs.length > 0) {
+      String[] tmp = new String[keepAttrs.length + extraAttrs.length];
+      System.arraycopy(keepAttrs, 0, tmp, 0, keepAttrs.length);
+      System.arraycopy(extraAttrs, 0, tmp, keepAttrs.length, extraAttrs.length);
+      keepAttrs = tmp;
     }
 
+    // Traverse all attributes, removing all except those on 'keep' list
+    for (int i = 0; i < fields.length; i++) {
+      fields[i].trimAttrsExcept(keepAttrs);
+    }
+    for (int i = 0; i < methods.length; i++) {
+      methods[i].trimAttrsExcept(keepAttrs);
+    }
 
-    // Instance Methods ------------------------------------------------------
-    // Private constructor.
-    private ClassFile() {}
+    attributes = AttrInfo.filter(attributes, keepAttrs);
+    u2attributesCount = attributes.length;
 
-    // Import the class data to internal representation.
-    private void read(DataInput din, boolean classVersionChecking) throws IOException
-    {
-        // Read the class file
-        u4magic = din.readInt();
-        u2minorVersion = din.readUnsignedShort();
-        u2majorVersion = din.readUnsignedShort();
+    // Signal that unknown attributes are gone
+    isUnkAttrGone = true;
 
-        // Check this is a valid classfile that we can handle
-        if (u4magic != MAGIC)
-        {
-            throw new IOException("Invalid magic number in class file.");
+    // Update the constant pool reference counts
+    constantPool.updateRefCount();
+  }
+
+  /**
+   * Gets inner class modifiers.
+   *
+   * @return the inner class modifiers
+   */
+  public Map getInnerClassModifiers() {
+    Map map = new HashMap();
+    for (int i = 0; i < u2attributesCount; i++) {
+      AttrInfo attrInfo = attributes[i];
+      if (attrInfo instanceof InnerClassesAttrInfo) {
+        InnerClassesInfo[] info = ((InnerClassesAttrInfo) attrInfo).getInfo();
+        for (int j = 0; j < info.length; j++) {
+          InnerClassesInfo ici = info[j];
+          int index = info[j].getInnerNameIndex();
+          if (index == 0) { // unnamed inner class
+            continue;
+          }
+          CpInfo cpInfo = getCpEntry(info[j].getInnerNameIndex());
+          if (cpInfo instanceof Utf8CpInfo) {
+            Utf8CpInfo utf = (Utf8CpInfo) cpInfo;
+            String origClass = utf.getString();
+            map.put(origClass, new Integer(ici.getModifiers()));
+          }
         }
-        if (u2majorVersion > MAJOR_VERSION)
-        {
-            if (classVersionChecking)
-            {
-                throw new IOException("Incompatible version number for class file format: " + u2majorVersion+"."+u2minorVersion);
+      }
+    }
+    return map;
+  }
+
+  private boolean containsDotClassMethodReference() {
+    // Need only check CONSTANT_Methodref entries of constant pool since
+    // dangerous methods belong to classes 'Class' and 'ClassLoader', not to interfaces.
+    for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); ) {
+      Object o = enumeration.nextElement();
+      if (o instanceof MethodrefCpInfo) {
+        // Get the method class name, simple name and descriptor
+        MethodrefCpInfo entry = (MethodrefCpInfo) o;
+        ClassCpInfo classEntry = (ClassCpInfo) getCpEntry(entry.getClassIndex());
+        String className = ((Utf8CpInfo) getCpEntry(classEntry.getNameIndex())).getString();
+        NameAndTypeCpInfo ntEntry = (NameAndTypeCpInfo) getCpEntry(entry.getNameAndTypeIndex());
+        String name = ((Utf8CpInfo) getCpEntry(ntEntry.getNameIndex())).getString();
+
+        if (name.equals("class$")) {
+          String descriptor = ((Utf8CpInfo) getCpEntry(ntEntry.getDescriptorIndex())).getString();
+          if (descriptor.equals("(Ljava/lang/String;)Ljava/lang/Class;")) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private boolean containsClassMethodReference( String cName, String des ) {
+    // Need only check CONSTANT_Methodref entries of constant pool since
+    // dangerous methods belong to classes 'Class' and 'ClassLoader', not to interfaces.
+    for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); ) {
+      Object o = enumeration.nextElement();
+      if (o instanceof MethodrefCpInfo) {
+        // Get the method class name, simple name and descriptor
+        MethodrefCpInfo entry = (MethodrefCpInfo) o;
+        ClassCpInfo classEntry = (ClassCpInfo) getCpEntry(entry.getClassIndex());
+        String className = ((Utf8CpInfo) getCpEntry(classEntry.getNameIndex())).getString();
+        NameAndTypeCpInfo ntEntry = (NameAndTypeCpInfo) getCpEntry(entry.getNameAndTypeIndex());
+        String name = ((Utf8CpInfo) getCpEntry(ntEntry.getNameIndex())).getString();
+        String descriptor = ((Utf8CpInfo) getCpEntry(ntEntry.getDescriptorIndex())).getString();
+
+        // Check if this is on the proscribed list
+        if (className.equals(cName) && (name + descriptor).equals(des)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Remap the entities in the specified ClassFile.
+   *
+   * @param nm                      the nm
+   * @param replaceClassNameStrings the replace class name strings
+   * @param log                     the log
+   */
+  public void remap( NameMapper nm, boolean replaceClassNameStrings, PrintWriter log ) {
+    // Remap all the package/interface/class/method/field names
+    //
+    String thisClassName = ((Utf8CpInfo) getCpEntry(((ClassCpInfo) getCpEntry(u2thisClass)).getNameIndex())).getString();
+
+    // Remove unnecessary attributes from the class
+    trimAttrsExcept(nm.getAttrsToKeep(thisClassName));
+
+    // Remap the 'inner name' reference of the 'InnerClasses' attribute
+    for (int i = 0; i < u2attributesCount; i++) {
+      AttrInfo attrInfo = attributes[i];
+      if (attrInfo instanceof RuntimeVisibleAnnotationsAttrInfo) {
+        remapAnnotations((RuntimeVisibleAnnotationsAttrInfo) attrInfo, nm);
+      } else if (attrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
+        remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attrInfo, nm);
+      } else if (attrInfo instanceof InnerClassesAttrInfo) {
+        // For each inner class referemce,
+        InnerClassesInfo[] info = ((InnerClassesAttrInfo) attrInfo).getInfo();
+        for (int j = 0; j < info.length; j++) {
+          // Get the 'inner name' (it is a CONSTANT_Utf8)
+          CpInfo cpInfo = getCpEntry(info[j].getInnerNameIndex());
+          if (cpInfo instanceof Utf8CpInfo) {
+            // Get the remapped class name
+            Utf8CpInfo utf = (Utf8CpInfo) cpInfo;
+            String origClass = utf.getString();
+
+            // Only remap non-anonymous classes (anon are "")
+            if (!origClass.equals("")) {
+              // Get the full inner class name
+              ClassCpInfo innerClassInfo = (ClassCpInfo) getCpEntry(info[j].getInnerClassIndex());
+              String innerClassName = ((Utf8CpInfo) getCpEntry(innerClassInfo.getNameIndex())).getString();
+
+              // It is the remapped simple name that must be stored, so truncate it
+              String remapClass = nm.mapClass(innerClassName);
+              remapClass = remapClass.substring(remapClass.lastIndexOf('$') + 1);
+              int remapIndex = constantPool.remapUtf8To(remapClass, info[j].getInnerNameIndex());
+              info[j].setInnerNameIndex(remapIndex);
             }
-            else
-            {
-                Logger.getInstance().warning("Incompatible version number for class file format: " + u2majorVersion+"."+u2minorVersion);
-            }
+          }
         }
+      } else if (attrInfo instanceof EnclosingMethodAttrInfo) {
+        EnclosingMethodAttrInfo eam = (EnclosingMethodAttrInfo) attrInfo;
 
+        // get the class name of the enclosing file:
+        CpInfo cpi = getCpEntry(eam.getClassIndex());
+        if (cpi instanceof ClassCpInfo) {
+          ClassCpInfo ccpi = (ClassCpInfo) cpi;
+          cpi = getCpEntry(ccpi.getNameIndex());
+          if (cpi instanceof Utf8CpInfo) {
+            Utf8CpInfo utf = (Utf8CpInfo) cpi;
+            String origClass = utf.getString();
 
-        int u2constantPoolCount = din.readUnsignedShort();
-        CpInfo[] cpInfo = new CpInfo[u2constantPoolCount];
-        // Fill the constant pool, recalling the zero entry
-        // is not persisted, nor are the entries following a Long or Double
-        for (int i = 1; i < u2constantPoolCount; i++)
-        {
-            cpInfo[i] = CpInfo.create(din);
-            if ((cpInfo[i] instanceof LongCpInfo) ||
-                (cpInfo[i] instanceof DoubleCpInfo))
-            {
-                i++;
-            }
-            // todo: remove once remapping CONSTANT_Dynamic_info is supported
-            else if (cpInfo[i] instanceof DynamicCpInfo) {
-                throw new IOException("Unsupported tag type in constant pool: dynamic");
-            }
-        }
-        constantPool = new ConstantPool(this, cpInfo);
+            // do not remap the ClassCpInfo now, it will be remapped automatically, later!
+            String remapClass = nm.mapClass(origClass);
 
-        u2accessFlags = din.readUnsignedShort();
-        u2thisClass = din.readUnsignedShort();
-        u2superClass = din.readUnsignedShort();
-        u2interfacesCount = din.readUnsignedShort();
-        u2interfaces = new int[u2interfacesCount];
-        for (int i = 0; i < u2interfacesCount; i++)
-        {
-            u2interfaces[i] = din.readUnsignedShort();
-        }
-        u2fieldsCount = din.readUnsignedShort();
-        fields = new FieldInfo[u2fieldsCount];
-        for (int i = 0; i < u2fieldsCount; i++)
-        {
-            fields[i] = FieldInfo.create(din, this);
-        }
-        u2methodsCount = din.readUnsignedShort();
-        methods = new MethodInfo[u2methodsCount];
-        for (int i = 0; i < u2methodsCount; i++)
-        {
-            methods[i] = MethodInfo.create(din, this);
-        }
-        u2attributesCount = din.readUnsignedShort();
-        attributes = new AttrInfo[u2attributesCount];
-        for (int i = 0; i < u2attributesCount; i++)
-        {
-            attributes[i] = AttrInfo.create(din, this);
-        }
-    }
-
-    /**
-     * Get class file access int.
-     *
-     * @return the int
-     */
-    public int getClassFileAccess() {
-      return u2accessFlags;
-    }
-
-    /**
-     * Get modifiers int.
-     *
-     * @return the int
-     */
-    public int getModifiers() {
-      int mods = 0;
-      if ((u2accessFlags & 0x0001) == 0x0001) mods |= Modifier.PUBLIC;
-      if ((u2accessFlags & 0x0010) == 0x0010) mods |= Modifier.FINAL;
-      if ((u2accessFlags & 0x0200) == 0x0200) mods |= Modifier.INTERFACE;
-      if ((u2accessFlags & 0x0400) == 0x0400) mods |= Modifier.ABSTRACT;
-      return mods;
-    }
-
-    /**
-     * Return the name of this classfile.
-     *
-     * @return the name
-     */
-    public String getName()
-    {
-        return toName(u2thisClass);
-    }
-
-    /**
-     * Return the name of this class's superclass.
-     *
-     * @return the super
-     */
-    public String getSuper()
-    {
-        // This may be java/lang/Object, in which case there is no super
-        return (u2superClass == 0) ? null : toName(u2superClass);
-    }
-
-    /**
-     * Return the names of this class's interfaces.
-     *
-     * @return the string [ ]
-     */
-    public String[] getInterfaces()
-    {
-        String[] interfaces = new String[u2interfacesCount];
-        for (int i = 0; i < u2interfacesCount; i++)
-        {
-            interfaces[i] = toName(u2interfaces[i]);
-        }
-        return interfaces;
-    }
-
-    // Convert a CP index to a class name.
-    private String toName(int u2index)
-    {
-        CpInfo classEntry = getCpEntry(u2index);
-        if (classEntry instanceof ClassCpInfo)
-        {
-            CpInfo nameEntry = getCpEntry(((ClassCpInfo)classEntry).getNameIndex());
-            if (nameEntry instanceof Utf8CpInfo)
-            {
-                return ((Utf8CpInfo)nameEntry).getString();
-            }
-            else
-            {
-                throw new ParseException("Inconsistent Constant Pool in class file.");
-            }
-        }
-        else
-        {
-            throw new ParseException("Inconsistent Constant Pool in class file.");
-        }
-    }
-
-    /**
-     * Return an enumeration of method name/descriptor pairs.
-     *
-     * @return the method enum
-     */
-    public Enumeration getMethodEnum()
-    {
-        Vector vec = new Vector();
-        for (int i = 0; i < methods.length; i++)
-        {
-            vec.addElement(methods[i]);
-        }
-        return vec.elements();
-    }
-
-    /**
-     * Return an enumeration of field name/descriptor pairs.
-     *
-     * @return the field enum
-     */
-    public Enumeration getFieldEnum()
-    {
-        Vector vec = new Vector();
-        for (int i = 0; i < fields.length; i++)
-        {
-          vec.addElement(fields[i]);
-        }
-        return vec.elements();
-    }
-
-    /**
-     * Lookup the entry in the constant pool and return as an Object.
-     *
-     * @param cpIndex the cp index
-     * @return the cp entry
-     */
-    public CpInfo getCpEntry(int cpIndex)
-    {
-        return constantPool.getCpEntry(cpIndex);
-    }
-
-    private String getUtf8(int cpIndex) {
-        return ((Utf8CpInfo) getCpEntry(cpIndex)).getString();
-    }
-
-    /**
-     * Gets constant pool.
-     *
-     * @return the constant pool
-     */
-    public ConstantPool getConstantPool() {
-        return constantPool;
-    }
-
-    /**
-     * Check for methods which can break the obfuscated code, and log them to a String[].
-     *
-     * @param replaceClassNameStrings the replace class name strings
-     * @return the string [ ]
-     */
-    public String[] logDangerousMethods(boolean replaceClassNameStrings)
-    {
-        Vector warningVec = new Vector();
-
-        // Need only check CONSTANT_Methodref entries of constant pool since
-        // dangerous methods belong to classes 'Class' and 'ClassLoader', not to interfaces.
-        for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); )
-        {
-            Object o = enumeration.nextElement();
-            if (o instanceof MethodrefCpInfo)
-            {
-                // Get the method class name, simple name and descriptor
-                MethodrefCpInfo entry = (MethodrefCpInfo)o;
-                ClassCpInfo classEntry = (ClassCpInfo)getCpEntry(entry.getClassIndex());
-                String className = ((Utf8CpInfo)getCpEntry(classEntry.getNameIndex())).getString();
-                NameAndTypeCpInfo ntEntry = (NameAndTypeCpInfo)getCpEntry(entry.getNameAndTypeIndex());
-                String name = ((Utf8CpInfo)getCpEntry(ntEntry.getNameIndex())).getString();
-                String descriptor = ((Utf8CpInfo)getCpEntry(ntEntry.getDescriptorIndex())).getString();
-
-                // Check if this is on the proscribed list
-                if (className.equals("java/lang/Class") &&
-                    Tools.isInArray(name + descriptor, DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY))
-                {
-                  if (replaceClassNameStrings){
-                    if (!Tools.isInArray(name+descriptor, SEMI_DANGEROUS_CLASS_SIMPLENAME_DESCRIPTOR_ARRAY)){
-                      String jMethod = Conversion.toJavaMethod(name, descriptor);
-                        warningVec.addElement(LOG_DANGER_CLASS_PRE + Conversion.toJavaClass(getName()) + LOG_DANGER_CLASS_MID + jMethod);
-                    }
-                  }
-                }
-                else if (Tools.isInArray(name + descriptor, DANGEROUS_CLASSLOADER_SIMPLENAME_DESCRIPTOR_ARRAY))
-                {
-                  String jMethod = Conversion.toJavaMethod(name, descriptor);
-                    warningVec.addElement(LOG_DANGER_CLASSLOADER_PRE + Conversion.toJavaClass(getName()) + LOG_DANGER_CLASSLOADER_MID + jMethod);
-                } else if ("class$(Ljava/lang/String;)Ljava/lang/Class;".equals(name+descriptor)){
-                  if (!replaceClassNameStrings){
-                     warningVec.addElement(LOG_DANGER_CLASS_PRE + Conversion.toJavaClass(getName()) +" seems to be using the '.class' construct!");
-                  }
-                }
-            }
-        }
-
-        // Copy any warnings to a String[]
-        String[] warnings = new String[warningVec.size()];
-        for (int i = 0; i < warnings.length; i++)
-        {
-            warnings[i] = (String)warningVec.elementAt(i);
-        }
-        return warnings;
-    }
-
-    /** Check for methods which can break the obfuscated code, and log them. */
-    private static boolean hasHeader = false;
-
-    /**
-     * Reset danger header.
-     */
-    public static void resetDangerHeader() {
-      hasHeader = false;
-    }
-
-    /**
-     * Log dangerous methods.
-     *
-     * @param log                     the log
-     * @param replaceClassNameStrings the replace class name strings
-     */
-    public void logDangerousMethods(PrintWriter log, boolean replaceClassNameStrings)
-    {
-        // Get any warnings and print them to the logfile
-        String[] warnings = logDangerousMethods(replaceClassNameStrings);
-        if (warnings != null && warnings.length > 0)
-        {
-            if (!hasHeader)
-            {
-                log.println("<!-- WARNING");
-                log.println(LOG_DANGER_HEADER1);
-                log.println(LOG_DANGER_HEADER2);
-                log.println(LOG_DANGER_HEADER3);
-
-                Logger logger = Logger.getInstance();
-                logger.warning(LOG_DANGER_HEADER1+'\n'+
-                               LOG_DANGER_HEADER2+'\n'+
-                               LOG_DANGER_HEADER3+'\n'+
-                               "See the logfile for a list of these classes and methods.");
-
-                log.println("-->");
-                hasHeader = true;
-            }
-            if (warnings.length > 0){
-              log.println("<!--");
-              for (int i = 0; i < warnings.length; i++)
-              {
-                  log.println(" " + warnings[i]);
+            // if NT > 0 there is a valid NT to be remapped
+            if (eam.getNameAndTypeIndex() > 0) {
+              cpi = getCpEntry(eam.getNameAndTypeIndex());
+              if (cpi instanceof NameAndTypeCpInfo) {
+                NameAndTypeCpInfo nameTypeInfo = (NameAndTypeCpInfo) cpi;
+                Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getNameIndex());
+                Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getDescriptorIndex());
+                String origMethodName = refUtf.getString();
+                String origDescriptor = descUtf.getString();
+                String remapRef = nm.mapMethod(origClass, origMethodName, origDescriptor);
+                String remapDesc = nm.mapDescriptor(descUtf.getString());
+                eam.setNameAndTypeIndex(remapNT(refUtf, remapRef, descUtf, remapDesc, nameTypeInfo, eam.getNameAndTypeIndex()));
               }
-              log.println("-->");
             }
+          }
         }
-    }
-
-    /**
-     * Check for direct references to Utf8 constant pool entries.
-     *
-     * @param pool the pool
-     */
-    public void markUtf8Refs(ConstantPool pool)
-    {
-        try
-        {
-            // Check for references to Utf8 from outside the constant pool
-            for (int i = 0; i < fields.length; i++)
-            {
-                fields[i].markUtf8Refs(pool);
-            }
-            for (int i = 0; i < methods.length; i++)
-            {
-                methods[i].markUtf8Refs(pool); // also checks Code/LVT attrs here
-            }
-            for (int i = 0; i < attributes.length; i++)
-            {
-                attributes[i].markUtf8Refs(pool); // checks InnerClasses, SourceFile and all attr names
-            }
-
-            // Now check for references from other CP entries
-            for (Enumeration enumeration = pool.elements(); enumeration.hasMoreElements(); )
-            {
-                Object o = enumeration.nextElement();
-                if (o instanceof NameAndTypeCpInfo ||
-                    o instanceof AbstractTypeCpInfo ||
-                    o instanceof MethodTypeCpInfo ||
-                    o instanceof StringCpInfo)
-                {
-                    ((CpInfo)o).markUtf8Refs(pool);
+      } else if (attrInfo instanceof SignatureAttrInfo) {
+        remapSignature(nm, (SignatureAttrInfo) attrInfo);
+      } else if (attrInfo instanceof SourceFileAttrInfo) {
+        SourceFileAttrInfo source = (SourceFileAttrInfo) attrInfo;
+        CpInfo cpInfo = getCpEntry(source.getSourceFileIndex());
+        if (cpInfo instanceof Utf8CpInfo) {
+          Utf8CpInfo utf = (Utf8CpInfo) cpInfo;
+          String origName = utf.getString();
+          if (origName != null && origName.length() > 0) {
+            String newName = nm.mapSourceFile(thisClassName, origName);
+            if (!origName.equals(newName)) {
+              if (newName == null || newName.length() < 1) {
+                AttrInfo[] newAttributes = new AttrInfo[attributes.length - 1];
+                System.arraycopy(attributes, 0, newAttributes, 0, i);
+                if (newAttributes.length > i) {
+                  System.arraycopy(attributes, i + 1, newAttributes, i, newAttributes.length - i);
                 }
-            }
-        }
-        catch (ArrayIndexOutOfBoundsException e)
-        {
-            throw new ParseException("Inconsistent reference to constant pool.");
-        }
-    }
-
-    /**
-     * Check for direct references to NameAndType constant pool entries.
-     *
-     * @param pool the pool
-     */
-    public void markNTRefs(ConstantPool pool)
-    {
-        try
-        {
-            // Now check the method and field CP entries
-            for (Enumeration enumeration = pool.elements(); enumeration.hasMoreElements(); )
-            {
-                Object o = enumeration.nextElement();
-                if (o instanceof RefCpInfo ||
-                    o instanceof AbstractDynamicCpInfo)
-                {
-                    ((CpInfo)o).markNTRefs(pool);
-                }
-            }
-        }
-        catch (ArrayIndexOutOfBoundsException e)
-        {
-            throw new ParseException("Inconsistent reference to constant pool.");
-        }
-    }
-
-    /**
-     * Trim attributes from the classfile ('Code', 'Exceptions', 'ConstantValue'
-     * are preserved, all others except the list in the String[] are killed).
-     *
-     * @param extraAttrs the extra attrs
-     */
-    public void trimAttrsExcept(String[] extraAttrs)
-    {
-        // Merge additional attributes with required list
-        String[] keepAttrs = REQUIRED_ATTRS;
-        if (extraAttrs != null && extraAttrs.length > 0)
-        {
-            String[] tmp = new String[keepAttrs.length + extraAttrs.length];
-            System.arraycopy(keepAttrs, 0, tmp, 0, keepAttrs.length);
-            System.arraycopy(extraAttrs, 0, tmp, keepAttrs.length, extraAttrs.length);
-            keepAttrs = tmp;
-        }
-
-        // Traverse all attributes, removing all except those on 'keep' list
-        for (int i = 0; i < fields.length; i++)
-        {
-            fields[i].trimAttrsExcept(keepAttrs);
-        }
-        for (int i = 0; i < methods.length; i++)
-        {
-            methods[i].trimAttrsExcept(keepAttrs);
-        }
-
-        attributes = AttrInfo.filter(attributes, keepAttrs);
-        u2attributesCount = attributes.length;
-
-        // Signal that unknown attributes are gone
-        isUnkAttrGone = true;
-
-        // Update the constant pool reference counts
-        constantPool.updateRefCount();
-    }
-
-    /**
-     * Gets inner class modifiers.
-     *
-     * @return the inner class modifiers
-     */
-    public Map getInnerClassModifiers()  {
-      Map map = new HashMap();
-        for (int i = 0; i < u2attributesCount; i++)
-        {
-            AttrInfo attrInfo = attributes[i];
-            if (attrInfo instanceof InnerClassesAttrInfo)
-            {
-                InnerClassesInfo[] info = ((InnerClassesAttrInfo)attrInfo).getInfo();
-                for (int j = 0; j < info.length; j++)
-                {
-                  InnerClassesInfo ici = info[j];
-                  int index = info[j].getInnerNameIndex();
-                  if (index == 0){ // unnamed inner class
-                    continue;
-                  }
-                  CpInfo cpInfo = getCpEntry(info[j].getInnerNameIndex());
-                  if (cpInfo instanceof Utf8CpInfo)
-                  {
-                      Utf8CpInfo utf = (Utf8CpInfo)cpInfo;
-                      String origClass = utf.getString();
-                      map.put(origClass, new Integer(ici.getModifiers()));
-                  }
-                }
-            }
-        }
-        return map;
-    }
-
-    private boolean containsDotClassMethodReference(){
-      // Need only check CONSTANT_Methodref entries of constant pool since
-        // dangerous methods belong to classes 'Class' and 'ClassLoader', not to interfaces.
-        for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); )
-        {
-            Object o = enumeration.nextElement();
-            if (o instanceof MethodrefCpInfo)
-            {
-                // Get the method class name, simple name and descriptor
-                MethodrefCpInfo entry = (MethodrefCpInfo)o;
-                ClassCpInfo classEntry = (ClassCpInfo)getCpEntry(entry.getClassIndex());
-                String className = ((Utf8CpInfo)getCpEntry(classEntry.getNameIndex())).getString();
-                NameAndTypeCpInfo ntEntry = (NameAndTypeCpInfo)getCpEntry(entry.getNameAndTypeIndex());
-                String name = ((Utf8CpInfo)getCpEntry(ntEntry.getNameIndex())).getString();
-
-                if (name.equals("class$")){
-                  String descriptor = ((Utf8CpInfo)getCpEntry(ntEntry.getDescriptorIndex())).getString();
-                  if (descriptor.equals("(Ljava/lang/String;)Ljava/lang/Class;")){
-                    return true;
-                  }
-                }
-            }
-        }
-        return false;
-    }
-
-    private boolean containsClassMethodReference(String cName, String des){
-      // Need only check CONSTANT_Methodref entries of constant pool since
-        // dangerous methods belong to classes 'Class' and 'ClassLoader', not to interfaces.
-        for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); )
-        {
-            Object o = enumeration.nextElement();
-            if (o instanceof MethodrefCpInfo)
-            {
-                // Get the method class name, simple name and descriptor
-                MethodrefCpInfo entry = (MethodrefCpInfo)o;
-                ClassCpInfo classEntry = (ClassCpInfo)getCpEntry(entry.getClassIndex());
-                String className = ((Utf8CpInfo)getCpEntry(classEntry.getNameIndex())).getString();
-                NameAndTypeCpInfo ntEntry = (NameAndTypeCpInfo)getCpEntry(entry.getNameAndTypeIndex());
-                String name = ((Utf8CpInfo)getCpEntry(ntEntry.getNameIndex())).getString();
-                String descriptor = ((Utf8CpInfo)getCpEntry(ntEntry.getDescriptorIndex())).getString();
-
-                // Check if this is on the proscribed list
-                if (className.equals(cName) && (name+descriptor).equals(des)){
-                  return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Remap the entities in the specified ClassFile.
-     *
-     * @param nm                      the nm
-     * @param replaceClassNameStrings the replace class name strings
-     * @param log                     the log
-     */
-    public void remap(NameMapper nm, boolean replaceClassNameStrings, PrintWriter log)
-    {
-        // Remap all the package/interface/class/method/field names
-        //
-        String thisClassName = ((Utf8CpInfo)getCpEntry(((ClassCpInfo)getCpEntry(u2thisClass)).getNameIndex())).getString();
-
-        // Remove unnecessary attributes from the class
-        trimAttrsExcept(nm.getAttrsToKeep(thisClassName));
-
-        // Remap the 'inner name' reference of the 'InnerClasses' attribute
-        for (int i = 0; i < u2attributesCount; i++)
-        {
-            AttrInfo attrInfo = attributes[i];
-            if (attrInfo instanceof RuntimeVisibleAnnotationsAttrInfo) {
-              remapAnnotations((RuntimeVisibleAnnotationsAttrInfo) attrInfo, nm);
-            } else if (attrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
-              remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attrInfo, nm);
-            } else if (attrInfo instanceof InnerClassesAttrInfo) {
-                // For each inner class referemce,
-                InnerClassesInfo[] info = ((InnerClassesAttrInfo)attrInfo).getInfo();
-                for (int j = 0; j < info.length; j++)
-                {
-                    // Get the 'inner name' (it is a CONSTANT_Utf8)
-                    CpInfo cpInfo = getCpEntry(info[j].getInnerNameIndex());
-                    if (cpInfo instanceof Utf8CpInfo)
-                    {
-                        // Get the remapped class name
-                        Utf8CpInfo utf = (Utf8CpInfo)cpInfo;
-                        String origClass = utf.getString();
-
-                        // Only remap non-anonymous classes (anon are "")
-                        if (!origClass.equals(""))
-                        {
-                            // Get the full inner class name
-                            ClassCpInfo innerClassInfo = (ClassCpInfo)getCpEntry(info[j].getInnerClassIndex());
-                            String innerClassName = ((Utf8CpInfo)getCpEntry(innerClassInfo.getNameIndex())).getString();
-
-                            // It is the remapped simple name that must be stored, so truncate it
-                            String remapClass = nm.mapClass(innerClassName);
-                            remapClass = remapClass.substring(remapClass.lastIndexOf('$') + 1);
-                            int remapIndex = constantPool.remapUtf8To(remapClass, info[j].getInnerNameIndex());
-                            info[j].setInnerNameIndex(remapIndex);
-                        }
-                    }
-                }
-            } else if (attrInfo instanceof EnclosingMethodAttrInfo){
-              EnclosingMethodAttrInfo eam = (EnclosingMethodAttrInfo) attrInfo;
-
-              // get the class name of the enclosing file:
-              CpInfo cpi = getCpEntry(eam.getClassIndex());
-              if (cpi instanceof ClassCpInfo){
-                ClassCpInfo ccpi = (ClassCpInfo) cpi;
-                cpi = getCpEntry(ccpi.getNameIndex());
-                if (cpi instanceof Utf8CpInfo){
-                  Utf8CpInfo utf = (Utf8CpInfo) cpi;
-                  String origClass = utf.getString();
-
-                  // do not remap the ClassCpInfo now, it will be remapped automatically, later!
-                  String remapClass = nm.mapClass(origClass);
-
-                  // if NT > 0 there is a valid NT to be remapped
-                  if (eam.getNameAndTypeIndex() > 0) {
-                    cpi = getCpEntry(eam.getNameAndTypeIndex());
-                    if (cpi instanceof NameAndTypeCpInfo){
-                      NameAndTypeCpInfo nameTypeInfo = (NameAndTypeCpInfo) cpi;
-                      Utf8CpInfo refUtf = (Utf8CpInfo)getCpEntry(nameTypeInfo.getNameIndex());
-                      Utf8CpInfo descUtf = (Utf8CpInfo)getCpEntry(nameTypeInfo.getDescriptorIndex());
-                      String origMethodName = refUtf.getString();
-                      String origDescriptor = descUtf.getString();
-                      String remapRef = nm.mapMethod(origClass, origMethodName, origDescriptor);
-                      String remapDesc = nm.mapDescriptor(descUtf.getString());
-                      eam.setNameAndTypeIndex(remapNT(refUtf, remapRef, descUtf, remapDesc, nameTypeInfo, eam.getNameAndTypeIndex()));
-                    }
-                  }
-                }
+                attributes = newAttributes;
+                u2attributesCount--;
+                i--;
+                constantPool.decRefCount(source.getAttrNameIndex());
+                utf.decRefCount();
+              } else {
+                int remapIndex = constantPool.remapUtf8To(newName, source.getSourceFileIndex());
+                source.setSourceFileIndex(remapIndex);
               }
-            } else if (attrInfo instanceof SignatureAttrInfo){
-              remapSignature(nm, (SignatureAttrInfo) attrInfo);
-            } else if (attrInfo instanceof SourceFileAttrInfo) {
-              SourceFileAttrInfo source = (SourceFileAttrInfo) attrInfo;
-              CpInfo cpInfo = getCpEntry(source.getSourceFileIndex());
-              if (cpInfo instanceof Utf8CpInfo){
-                Utf8CpInfo utf = (Utf8CpInfo) cpInfo;
-                String origName = utf.getString();
-                if (origName != null && origName.length() > 0){
-                  String newName = nm.mapSourceFile(thisClassName, origName);
-                  if (!origName.equals(newName)){
-                    if (newName == null || newName.length() < 1){
-                      AttrInfo[] newAttributes = new AttrInfo[attributes.length - 1];
-                      System.arraycopy(attributes, 0, newAttributes, 0, i);
-                      if (newAttributes.length > i){
-                        System.arraycopy(attributes, i + 1, newAttributes, i, newAttributes.length - i);
-                      }
-                      attributes = newAttributes;
-                      u2attributesCount--;
-                      i--;
-                      constantPool.decRefCount(source.getAttrNameIndex());
-                      utf.decRefCount();
-                    } else {
-                      int remapIndex = constantPool.remapUtf8To(newName, source.getSourceFileIndex());
-                      source.setSourceFileIndex(remapIndex);
-                    }
-                  }
-                }
-              }
+            }
+          }
+        }
 //            } else if (attrInfo instanceof ModuleAttrInfo) {
-                // should not be necessary to adjust anything because the
-                // attribute references
-                //   CONSTANT_Class_Info,
-                //   CONSTANT_Module_Info, and
-                //   CONSTANT_Package_Info
-                // structures
+        // should not be necessary to adjust anything because the
+        // attribute references
+        //   CONSTANT_Class_Info,
+        //   CONSTANT_Module_Info, and
+        //   CONSTANT_Package_Info
+        // structures
 //            } else if (attrInfo instanceof ModuleMainClassAttrInfo) {
-                // should not be necessary to adjust anything because the
-                // attribute references a
-                //   CONSTANT_Class_Info
-                // structure
+        // should not be necessary to adjust anything because the
+        // attribute references a
+        //   CONSTANT_Class_Info
+        // structure
 //            } else if (attrInfo instanceof ModulePackagesAttrInfo) {
-                // should not be necessary to adjust anything because the
-                // attribute references
-                //   CONSTANT_Package_Info
-                // structures
-            } else if (attrInfo instanceof RecordAttrInfo) {
-              final RecordAttrInfo record = (RecordAttrInfo) attrInfo;
-              final RecordComponent[] components = record.getComponents();
-              for (int j = 0, n = components.length; j < n; ++j) {
-                final int nameIndex = components[j].getNameIndex();
-                final Utf8CpInfo nameUtf = (Utf8CpInfo) getCpEntry(nameIndex);
-                final String remapName = nm.mapField(thisClassName, nameUtf.getString());
-                final int remapNameIndex = constantPool.remapUtf8To(remapName, nameIndex);
-                components[j].setNameIndex(remapNameIndex);
+        // should not be necessary to adjust anything because the
+        // attribute references
+        //   CONSTANT_Package_Info
+        // structures
+      } else if (attrInfo instanceof RecordAttrInfo) {
+        final RecordAttrInfo record = (RecordAttrInfo) attrInfo;
+        final RecordComponent[] components = record.getComponents();
+        for (int j = 0, n = components.length; j < n; ++j) {
+          final int nameIndex = components[j].getNameIndex();
+          final Utf8CpInfo nameUtf = (Utf8CpInfo) getCpEntry(nameIndex);
+          final String remapName = nm.mapField(thisClassName, nameUtf.getString());
+          final int remapNameIndex = constantPool.remapUtf8To(remapName, nameIndex);
+          components[j].setNameIndex(remapNameIndex);
 
-                final int descIndex = components[j].getDescriptorIndex();
-                final Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(descIndex);
-                final String remapDesc = nm.mapDescriptor(descUtf.getString());
-                final int remapDescIndex = constantPool.remapUtf8To(remapDesc, descIndex);
-                components[j].setDescriptorIndex(remapDescIndex);
+          final int descIndex = components[j].getDescriptorIndex();
+          final Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(descIndex);
+          final String remapDesc = nm.mapDescriptor(descUtf.getString());
+          final int remapDescIndex = constantPool.remapUtf8To(remapDesc, descIndex);
+          components[j].setDescriptorIndex(remapDescIndex);
 
-                // attributes:
-                // - Signature
-                //   Nothing to do.
-                //   Such a signature is always a simple name that does not
-                //   need to be changed.
+          // attributes:
+          // - Signature
+          //   Nothing to do.
+          //   Such a signature is always a simple name that does not
+          //   need to be changed.
 
-                // - RuntimeVisibleAnnotations
-                // - RuntimeInvisibleAnnotations
-                // - RuntimeVisibleTypeAnnotations
-                // - RuntimeInvisibleTypeAnnotations
-                final AttrInfo[] attributes = components[j].getAttributes();
-                for (int k = 0; k < attributes.length; ++k) {
-                  if (attributes[k] instanceof RuntimeVisibleAnnotationsAttrInfo) {
-                    remapAnnotations((RuntimeVisibleAnnotationsAttrInfo) attributes[k], nm);
-                  } else if (attributes[k] instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
-                    remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attributes[k], nm);
+          // - RuntimeVisibleAnnotations
+          // - RuntimeInvisibleAnnotations
+          // - RuntimeVisibleTypeAnnotations
+          // - RuntimeInvisibleTypeAnnotations
+          final AttrInfo[] attributes = components[j].getAttributes();
+          for (int k = 0; k < attributes.length; ++k) {
+            if (attributes[k] instanceof RuntimeVisibleAnnotationsAttrInfo) {
+              remapAnnotations((RuntimeVisibleAnnotationsAttrInfo) attributes[k], nm);
+            } else if (attributes[k] instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
+              remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attributes[k], nm);
+            }
+          }
+        }
+      }
+    }
+
+    // Remap the 'name' and 'descriptor' references of the 'LocalVariableTable'
+    // attribute, in the 'Code' attribute of method structures.
+    for (int i = 0; i < u2methodsCount; i++) {
+      for (int j = 0; j < methods[i].u2attributesCount; j++) {
+        final String methodName = methods[i].getName();
+        final String descriptor = methods[i].getDescriptor();
+        AttrInfo attrInfo = methods[i].attributes[j];
+
+        if (attrInfo instanceof AnnotationDefaultAttrInfo) {
+          remapAnnotationDefault((AnnotationDefaultAttrInfo) attrInfo, nm);
+        } else if (attrInfo instanceof RuntimeVisibleAnnotationsAttrInfo) {
+          remapAnnotations((RuntimeVisibleAnnotationsAttrInfo) attrInfo, nm);
+        } else if (attrInfo instanceof RuntimeVisibleParameterAnnotationsAttrInfo) {
+          remapParameterAnnotations((RuntimeVisibleParameterAnnotationsAttrInfo) attrInfo, nm);
+        } else if (attrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
+          remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attrInfo, nm);
+        } else if (attrInfo instanceof SignatureAttrInfo) {
+          remapSignature(nm, (SignatureAttrInfo) attrInfo);
+        } else if (attrInfo instanceof CodeAttrInfo) {
+          CodeAttrInfo codeAttrInfo = (CodeAttrInfo) attrInfo;
+          for (int k = 0; k < codeAttrInfo.u2attributesCount; k++) {
+            AttrInfo innerAttrInfo = codeAttrInfo.attributes[k];
+            if (innerAttrInfo instanceof LocalVariableTableAttrInfo) {
+              LocalVariableTableAttrInfo lvtAttrInfo = (LocalVariableTableAttrInfo) innerAttrInfo;
+              LocalVariableInfo[] lvts = lvtAttrInfo.getLocalVariableTable();
+              for (int m = 0; m < lvts.length; m++) {
+                // Remap name
+                Utf8CpInfo nameUtf = (Utf8CpInfo) getCpEntry(lvts[m].getNameIndex());
+                String remapName = nm.mapLocalVariable(thisClassName, methodName, descriptor, nameUtf.getString());
+                if (remapName == null || remapName.length() < 1) {
+                  constantPool.decRefCount(lvts[m].getNameIndex());
+                  constantPool.decRefCount(lvts[m].getDescriptorIndex());
+                  LocalVariableInfo[] newArray = new LocalVariableInfo[lvts.length - 1];
+                  System.arraycopy(lvts, 0, newArray, 0, m);
+                  if (newArray.length > m) {
+                    System.arraycopy(lvts, m + 1, newArray, m, newArray.length - m);
                   }
+                  lvts = newArray;
+                  lvtAttrInfo.setLocalVariableTable(lvts);
+                  m--;
+                } else {
+                  lvts[m].setNameIndex(constantPool.remapUtf8To(remapName, lvts[m].getNameIndex()));
+
+                  // Remap descriptor
+                  Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(lvts[m].getDescriptorIndex());
+                  String remapDesc = nm.mapDescriptor(descUtf.getString());
+                  lvts[m].setDescriptorIndex(constantPool.remapUtf8To(remapDesc, lvts[m].getDescriptorIndex()));
                 }
               }
-            }
-        }
+            } else if (innerAttrInfo instanceof LocalVariableTypeTableAttrInfo) {
+              LocalVariableTypeTableAttrInfo lvttAttrInfo = (LocalVariableTypeTableAttrInfo) innerAttrInfo;
+              LocalVariableTypeInfo[] lvts = lvttAttrInfo.getLocalVariableTypeTable();
+              for (int m = 0; m < lvts.length; m++) {
+                // Remap name
+                Utf8CpInfo nameUtf = (Utf8CpInfo) getCpEntry(lvts[m].getNameIndex());
+                String remapName = nm.mapLocalVariable(thisClassName, methodName, descriptor, nameUtf.getString());
+                if (remapName == null || remapName.length() < 1) {
+                  constantPool.decRefCount(lvts[m].getNameIndex());
+                  constantPool.decRefCount(lvts[m].getSignatureIndex());
+                  LocalVariableTypeInfo[] newArray = new LocalVariableTypeInfo[lvts.length - 1];
+                  System.arraycopy(lvts, 0, newArray, 0, m);
+                  if (newArray.length > m) {
+                    System.arraycopy(lvts, m + 1, newArray, m, newArray.length - m);
+                  }
+                  lvts = newArray;
+                  lvttAttrInfo.setLocalVariableTypeTable(lvts);
+                  m--;
+                } else {
+                  lvts[m].setNameIndex(constantPool.remapUtf8To(remapName, lvts[m].getNameIndex()));
 
-        // Remap the 'name' and 'descriptor' references of the 'LocalVariableTable'
-        // attribute, in the 'Code' attribute of method structures.
-        for (int i = 0; i < u2methodsCount; i++)
-        {
-            for (int j = 0; j < methods[i].u2attributesCount; j++)
-            {
-                final String methodName = methods[i].getName();
-                final String descriptor = methods[i].getDescriptor();
-                AttrInfo attrInfo = methods[i].attributes[j];
-
-                if (attrInfo instanceof AnnotationDefaultAttrInfo){
-                  remapAnnotationDefault((AnnotationDefaultAttrInfo)attrInfo, nm);
-                } else if (attrInfo instanceof RuntimeVisibleAnnotationsAttrInfo){
-                  remapAnnotations((RuntimeVisibleAnnotationsAttrInfo)attrInfo, nm);
-                } else if (attrInfo instanceof RuntimeVisibleParameterAnnotationsAttrInfo){
-                  remapParameterAnnotations((RuntimeVisibleParameterAnnotationsAttrInfo)attrInfo, nm);
-                } else if (attrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
-                  remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attrInfo, nm);
-                } else if (attrInfo instanceof SignatureAttrInfo){
-                  remapSignature(nm, (SignatureAttrInfo) attrInfo);
-                } else if (attrInfo instanceof CodeAttrInfo) {
-                    CodeAttrInfo codeAttrInfo = (CodeAttrInfo)attrInfo;
-                    for (int k = 0; k < codeAttrInfo.u2attributesCount; k++) {
-                        AttrInfo innerAttrInfo = codeAttrInfo.attributes[k];
-                        if (innerAttrInfo instanceof LocalVariableTableAttrInfo) {
-                            LocalVariableTableAttrInfo lvtAttrInfo = (LocalVariableTableAttrInfo)innerAttrInfo;
-                            LocalVariableInfo[] lvts = lvtAttrInfo.getLocalVariableTable();
-                            for (int m = 0; m < lvts.length; m++) {
-                                // Remap name
-                                Utf8CpInfo nameUtf = (Utf8CpInfo)getCpEntry(lvts[m].getNameIndex());
-                                String remapName = nm.mapLocalVariable(thisClassName, methodName, descriptor, nameUtf.getString());
-                                if (remapName == null || remapName.length() < 1){
-                                  constantPool.decRefCount(lvts[m].getNameIndex());
-                                  constantPool.decRefCount(lvts[m].getDescriptorIndex());
-                                  LocalVariableInfo[] newArray = new LocalVariableInfo[lvts.length - 1];
-                                  System.arraycopy(lvts, 0, newArray, 0, m);
-                                  if (newArray.length > m ){
-                                    System.arraycopy(lvts, m + 1, newArray, m, newArray.length - m);
-                                  }
-                                  lvts = newArray;
-                                  lvtAttrInfo.setLocalVariableTable(lvts);
-                                  m--;
-                                } else {
-                                  lvts[m].setNameIndex(constantPool.remapUtf8To(remapName, lvts[m].getNameIndex()));
-
-                                  // Remap descriptor
-                                  Utf8CpInfo descUtf = (Utf8CpInfo)getCpEntry(lvts[m].getDescriptorIndex());
-                                  String remapDesc = nm.mapDescriptor(descUtf.getString());
-                                  lvts[m].setDescriptorIndex(constantPool.remapUtf8To(remapDesc, lvts[m].getDescriptorIndex()));
-                                }
-                            }
-                        } else if (innerAttrInfo instanceof LocalVariableTypeTableAttrInfo) {
-                            LocalVariableTypeTableAttrInfo lvttAttrInfo = (LocalVariableTypeTableAttrInfo) innerAttrInfo;
-                            LocalVariableTypeInfo[] lvts = lvttAttrInfo.getLocalVariableTypeTable();
-                            for (int m = 0; m < lvts.length; m++){
-                              // Remap name
-                              Utf8CpInfo nameUtf = (Utf8CpInfo)getCpEntry(lvts[m].getNameIndex());
-                              String remapName = nm.mapLocalVariable(thisClassName, methodName, descriptor, nameUtf.getString());
-                              if (remapName == null || remapName.length() < 1){
-                                constantPool.decRefCount(lvts[m].getNameIndex());
-                                constantPool.decRefCount(lvts[m].getSignatureIndex());
-                                LocalVariableTypeInfo[] newArray = new LocalVariableTypeInfo[lvts.length - 1];
-                                System.arraycopy(lvts, 0, newArray, 0, m);
-                                if (newArray.length > m ){
-                                  System.arraycopy(lvts, m + 1, newArray, m, newArray.length - m);
-                                }
-                                lvts = newArray;
-                                lvttAttrInfo.setLocalVariableTypeTable(lvts);
-                                m--;
-                              } else {
-                                lvts[m].setNameIndex(constantPool.remapUtf8To(remapName, lvts[m].getNameIndex()));
-
-                                // Remap descriptor
-                                Utf8CpInfo signatureUtf = (Utf8CpInfo)getCpEntry(lvts[m].getSignatureIndex());
-                                String remapSig = nm.mapSignature(signatureUtf.getString());
-                                lvts[m].setSignatureIndex(constantPool.remapUtf8To(remapSig, lvts[m].getSignatureIndex()));
-                              }
-                            }
-                        } else if (innerAttrInfo instanceof LineNumberTableAttrInfo) {
-                           LineNumberTableAttrInfo ltai = (LineNumberTableAttrInfo) innerAttrInfo;
-                           if (!nm.mapLineNumberTable(thisClassName, methodName, descriptor, ltai)){
-                              AttrInfo[] newAtt = new AttrInfo[codeAttrInfo.u2attributesCount - 1];
-                              System.arraycopy(codeAttrInfo.attributes, 0, newAtt, 0, k);
-                              if (newAtt.length > k ){
-                                System.arraycopy(codeAttrInfo.attributes, k + 1, newAtt, k, newAtt.length - k);
-                              }
-                              codeAttrInfo.attributes = newAtt;
-                              codeAttrInfo.u2attributesCount--;
-                              k--;
-                           }
-                        } else if (innerAttrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
-                          remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) innerAttrInfo, nm);
-                        }
-                    }
+                  // Remap descriptor
+                  Utf8CpInfo signatureUtf = (Utf8CpInfo) getCpEntry(lvts[m].getSignatureIndex());
+                  String remapSig = nm.mapSignature(signatureUtf.getString());
+                  lvts[m].setSignatureIndex(constantPool.remapUtf8To(remapSig, lvts[m].getSignatureIndex()));
                 }
-            }
-        }
-
-        // Go through all of class's fields and methods mapping 'name' and 'descriptor' references
-        for (int i = 0; i < u2fieldsCount; i++)
-        {
-            // Remap field 'name', unless it is 'Synthetic'
-            FieldInfo field = fields[i];
-            Utf8CpInfo nameUtf = (Utf8CpInfo)getCpEntry(field.getNameIndex());
-            if (!field.isSynthetic() || nameUtf.getString().startsWith("class$"))
-            {
-                String remapName = nm.mapField(thisClassName, nameUtf.getString());
-                field.setNameIndex(constantPool.remapUtf8To(remapName, field.getNameIndex()));
-            }
-
-            for (int j = 0; j < field.u2attributesCount; j++){
-              AttrInfo attrInfo = field.attributes[j];
-              if (attrInfo instanceof RuntimeVisibleAnnotationsAttrInfo){
-                remapAnnotations((RuntimeVisibleAnnotationsAttrInfo)attrInfo, nm);
-              } else if (attrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
-                remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attrInfo, nm);
-              } else if (attrInfo instanceof SignatureAttrInfo){
-                remapSignature(nm, (SignatureAttrInfo) attrInfo);
               }
+            } else if (innerAttrInfo instanceof LineNumberTableAttrInfo) {
+              LineNumberTableAttrInfo ltai = (LineNumberTableAttrInfo) innerAttrInfo;
+              if (!nm.mapLineNumberTable(thisClassName, methodName, descriptor, ltai)) {
+                AttrInfo[] newAtt = new AttrInfo[codeAttrInfo.u2attributesCount - 1];
+                System.arraycopy(codeAttrInfo.attributes, 0, newAtt, 0, k);
+                if (newAtt.length > k) {
+                  System.arraycopy(codeAttrInfo.attributes, k + 1, newAtt, k, newAtt.length - k);
+                }
+                codeAttrInfo.attributes = newAtt;
+                codeAttrInfo.u2attributesCount--;
+                k--;
+              }
+            } else if (innerAttrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
+              remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) innerAttrInfo, nm);
             }
-
-            // Remap field 'descriptor'
-            Utf8CpInfo descUtf = (Utf8CpInfo)getCpEntry(field.getDescriptorIndex());
-            String remapDesc = nm.mapDescriptor(descUtf.getString());
-            field.setDescriptorIndex(constantPool.remapUtf8To(remapDesc, field.getDescriptorIndex()));
+          }
         }
-        for (int i = 0; i < u2methodsCount; i++)
-        {
-            // Remap method 'name', unless it is 'Synthetic'
-            MethodInfo method = methods[i];
-            Utf8CpInfo descUtf = (Utf8CpInfo)getCpEntry(method.getDescriptorIndex());
-            if (!method.isSynthetic())
-            {
-                Utf8CpInfo nameUtf = (Utf8CpInfo)getCpEntry(method.getNameIndex());
-                String remapName = nm.mapMethod(thisClassName, nameUtf.getString(), descUtf.getString());
-                method.setNameIndex(constantPool.remapUtf8To(remapName, method.getNameIndex()));
-            }
+      }
+    }
 
-            // Remap method 'descriptor'
-            String remapDesc = nm.mapDescriptor(descUtf.getString());
-            method.setDescriptorIndex(constantPool.remapUtf8To(remapDesc, method.getDescriptorIndex()));
+    // Go through all of class's fields and methods mapping 'name' and 'descriptor' references
+    for (int i = 0; i < u2fieldsCount; i++) {
+      // Remap field 'name', unless it is 'Synthetic'
+      FieldInfo field = fields[i];
+      Utf8CpInfo nameUtf = (Utf8CpInfo) getCpEntry(field.getNameIndex());
+      if (!field.isSynthetic() || nameUtf.getString().startsWith("class$")) {
+        String remapName = nm.mapField(thisClassName, nameUtf.getString());
+        field.setNameIndex(constantPool.remapUtf8To(remapName, field.getNameIndex()));
+      }
+
+      for (int j = 0; j < field.u2attributesCount; j++) {
+        AttrInfo attrInfo = field.attributes[j];
+        if (attrInfo instanceof RuntimeVisibleAnnotationsAttrInfo) {
+          remapAnnotations((RuntimeVisibleAnnotationsAttrInfo) attrInfo, nm);
+        } else if (attrInfo instanceof RuntimeVisibleTypeAnnotationsAttrInfo) {
+          remapTypeAnnotations((RuntimeVisibleTypeAnnotationsAttrInfo) attrInfo, nm);
+        } else if (attrInfo instanceof SignatureAttrInfo) {
+          remapSignature(nm, (SignatureAttrInfo) attrInfo);
         }
+      }
 
-        // check whether .class constructs of Class.forName calls reside in the code..
-        if (replaceClassNameStrings && nm instanceof ClassTree)
+      // Remap field 'descriptor'
+      Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(field.getDescriptorIndex());
+      String remapDesc = nm.mapDescriptor(descUtf.getString());
+      field.setDescriptorIndex(constantPool.remapUtf8To(remapDesc, field.getDescriptorIndex()));
+    }
+    for (int i = 0; i < u2methodsCount; i++) {
+      // Remap method 'name', unless it is 'Synthetic'
+      MethodInfo method = methods[i];
+      Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(method.getDescriptorIndex());
+      if (!method.isSynthetic()) {
+        Utf8CpInfo nameUtf = (Utf8CpInfo) getCpEntry(method.getNameIndex());
+        String remapName = nm.mapMethod(thisClassName, nameUtf.getString(), descUtf.getString());
+        method.setNameIndex(constantPool.remapUtf8To(remapName, method.getNameIndex()));
+      }
+
+      // Remap method 'descriptor'
+      String remapDesc = nm.mapDescriptor(descUtf.getString());
+      method.setDescriptorIndex(constantPool.remapUtf8To(remapDesc, method.getDescriptorIndex()));
+    }
+
+    // check whether .class constructs of Class.forName calls reside in the code..
+    if (replaceClassNameStrings && nm instanceof ClassTree)
 //          && 
 //          (containsClassMethodReference("java/lang/Class","forName(Ljava/lang/String;)Ljava/lang/Class;")) ||
 //          (containsClassMethodReference("java/lang/Class","forName(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;")) ||
 //          (containsDotClassMethodReference()))
-        {
-            this.replaceConstantPoolStrings((ClassTree)nm);
-        }
+    {
+      this.replaceConstantPoolStrings((ClassTree) nm);
+    }
 
-      final LinkedHashSet ombIndicies = new LinkedHashSet();
-      int currentCpLength = constantPool.length(); // constant pool can be extended (never contracted) during loop
-        for (int i = 0; i < currentCpLength; i++) {
-            CpInfo cpInfo = getCpEntry(i);
-            if (cpInfo != null) {
-                // If this is an entry that references Descriptors and/or names, adjust them correspondingly
-                if (cpInfo instanceof InvokeDynamicCpInfo) {
-                    InvokeDynamicCpInfo id = (InvokeDynamicCpInfo) cpInfo;
+    final LinkedHashSet ombIndicies = new LinkedHashSet();
+    int currentCpLength = constantPool.length(); // constant pool can be extended (never contracted) during loop
+    for (int i = 0; i < currentCpLength; i++) {
+      CpInfo cpInfo = getCpEntry(i);
+      if (cpInfo != null) {
+        // If this is an entry that references Descriptors and/or names, adjust them correspondingly
+        if (cpInfo instanceof InvokeDynamicCpInfo) {
+          InvokeDynamicCpInfo id = (InvokeDynamicCpInfo) cpInfo;
 
-                    final BootstrapMethod bm = getBootstrapMethod(id);
-                    switch (getType(bm)) {
-                        case BM_TYPE_LMF: {
-                            NameAndTypeCpInfo nameTypeInfo = (NameAndTypeCpInfo) getCpEntry(id.getNameAndTypeIndex());
-                            Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getNameIndex());
-                            Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getDescriptorIndex());
+          final BootstrapMethod bm = getBootstrapMethod(id);
+          switch (getType(bm)) {
+            case BM_TYPE_LMF: {
+              NameAndTypeCpInfo nameTypeInfo = (NameAndTypeCpInfo) getCpEntry(id.getNameAndTypeIndex());
+              Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getNameIndex());
+              Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getDescriptorIndex());
 
-                            final String descriptor = descUtf.getString();
-                            String className = descriptor.substring(descriptor.indexOf(")L") + 2, descriptor.length() - 1);
+              final String descriptor = descUtf.getString();
+              String className = descriptor.substring(descriptor.indexOf(")L") + 2, descriptor.length() - 1);
 
-                            // find out the method descriptor of the method
-                            MethodTypeCpInfo methodTypeInfo = (MethodTypeCpInfo) getCpEntry(bm.getBootstrapArguments()[0]);
-                            Utf8CpInfo samMethodDescriptor = (Utf8CpInfo) getCpEntry(methodTypeInfo.getU2descriptorIndex());
-                            // now find the mapping of the method
-                            String remapName = nm.mapMethod(className, refUtf.getString(), samMethodDescriptor.getString());
-                            String remapDesc = nm.mapDescriptor(descUtf.getString());
+              // find out the method descriptor of the method
+              MethodTypeCpInfo methodTypeInfo = (MethodTypeCpInfo) getCpEntry(bm.getBootstrapArguments()[0]);
+              Utf8CpInfo samMethodDescriptor = (Utf8CpInfo) getCpEntry(methodTypeInfo.getU2descriptorIndex());
+              // now find the mapping of the method
+              String remapName = nm.mapMethod(className, refUtf.getString(), samMethodDescriptor.getString());
+              String remapDesc = nm.mapDescriptor(descUtf.getString());
 
-                            id.setNameAndTypeIndex(remapNT(refUtf, remapName, descUtf, remapDesc, nameTypeInfo, id.getNameAndTypeIndex()));
-                        }   break;
-                        case BM_TYPE_SCF: {
-                            final int idx = id.getNameAndTypeIndex();
-
-                            final NameAndTypeCpInfo ntInfo = (NameAndTypeCpInfo) getCpEntry(idx);
-                            final Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(ntInfo.getNameIndex());
-                            final Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(ntInfo.getDescriptorIndex());
-
-                            final String remapDesc = nm.mapDescriptor(descUtf.getString());
-
-                            id.setNameAndTypeIndex(remapNT(refUtf, refUtf.getString(), descUtf, remapDesc, ntInfo, idx));
-                        }   break;
-                        case BM_TYPE_OM: {
-                            ombIndicies.add(Integer.valueOf(id.getBootstrapMethodAttrIndex()));
-
-                            final int idx = id.getNameAndTypeIndex();
-
-                            final NameAndTypeCpInfo ntInfo = (NameAndTypeCpInfo) getCpEntry(idx);
-                            final Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(ntInfo.getNameIndex());
-                            final Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(ntInfo.getDescriptorIndex());
-
-                            final String remapDesc = nm.mapDescriptor(descUtf.getString());
-
-                            id.setNameAndTypeIndex(remapNT(refUtf, refUtf.getString(), descUtf, remapDesc, ntInfo, idx));
-                        }   break;
-                        default:
-                            final String sig = getBootstrapMethodSignature(bm);
-                            throw new IllegalArgumentException("Unrecognized bootstrap method: " + sig);
-                    }
-
-                }
+              id.setNameAndTypeIndex(remapNT(refUtf, remapName, descUtf, remapDesc, nameTypeInfo, id.getNameAndTypeIndex()));
             }
-        }
-        if (!ombIndicies.isEmpty()) {
-          final BootstrapMethodsAttrInfo attr = getBootstrapMethodAttribute();
-          for (Iterator it = ombIndicies.iterator(); it.hasNext(); ) {
-            final BootstrapMethod bm = attr.getBootstrapMethods()[((Integer) it.next()).intValue()];
+            break;
+            case BM_TYPE_SCF: {
+              final int idx = id.getNameAndTypeIndex();
 
-            final StringCpInfo namesInfo = (StringCpInfo) getCpEntry(bm.getBootstrapArguments()[1]);
-            final Utf8CpInfo names = (Utf8CpInfo) getCpEntry(namesInfo.getStringIndex());
-            final StringBuilder sb = new StringBuilder();
-            final String delim = ";";
-            for (StringTokenizer st = new StringTokenizer(names.getString(), delim, true); st.hasMoreTokens();) {
-              final String origName = st.nextToken();
-              if (delim.equals(origName)) {
-                sb.append(delim);
-              } else {
-                sb.append(nm.mapField(thisClassName, origName));
+              final NameAndTypeCpInfo ntInfo = (NameAndTypeCpInfo) getCpEntry(idx);
+              final Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(ntInfo.getNameIndex());
+              final Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(ntInfo.getDescriptorIndex());
+
+              final String remapDesc = nm.mapDescriptor(descUtf.getString());
+
+              id.setNameAndTypeIndex(remapNT(refUtf, refUtf.getString(), descUtf, remapDesc, ntInfo, idx));
+            }
+            break;
+            case BM_TYPE_OM: {
+              ombIndicies.add(Integer.valueOf(id.getBootstrapMethodAttrIndex()));
+
+              final int idx = id.getNameAndTypeIndex();
+
+              final NameAndTypeCpInfo ntInfo = (NameAndTypeCpInfo) getCpEntry(idx);
+              final Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(ntInfo.getNameIndex());
+              final Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(ntInfo.getDescriptorIndex());
+
+              final String remapDesc = nm.mapDescriptor(descUtf.getString());
+
+              id.setNameAndTypeIndex(remapNT(refUtf, refUtf.getString(), descUtf, remapDesc, ntInfo, idx));
+            }
+            break;
+            default:
+              final String sig = getBootstrapMethodSignature(bm);
+              throw new IllegalArgumentException("Unrecognized bootstrap method: " + sig);
+          }
+
+        }
+      }
+    }
+    if (!ombIndicies.isEmpty()) {
+      final BootstrapMethodsAttrInfo attr = getBootstrapMethodAttribute();
+      for (Iterator it = ombIndicies.iterator(); it.hasNext(); ) {
+        final BootstrapMethod bm = attr.getBootstrapMethods()[((Integer) it.next()).intValue()];
+
+        final StringCpInfo namesInfo = (StringCpInfo) getCpEntry(bm.getBootstrapArguments()[1]);
+        final Utf8CpInfo names = (Utf8CpInfo) getCpEntry(namesInfo.getStringIndex());
+        final StringBuilder sb = new StringBuilder();
+        final String delim = ";";
+        for (StringTokenizer st = new StringTokenizer(names.getString(), delim, true); st.hasMoreTokens(); ) {
+          final String origName = st.nextToken();
+          if (delim.equals(origName)) {
+            sb.append(delim);
+          } else {
+            sb.append(nm.mapField(thisClassName, origName));
+          }
+        }
+        final String remapNames = sb.toString();
+        final int remapNamesIndex = constantPool.addUtf8Entry(remapNames);
+        final StringCpInfo remapNamesInfo = new StringCpInfo();
+        remapNamesInfo.setStringIndex(remapNamesIndex);
+        final int remapNamesInfoIndex = constantPool.addEntry(remapNamesInfo);
+        bm.getBootstrapArguments()[1] = remapNamesInfoIndex;
+      }
+    }
+
+    // Remap all field/method names and descriptors in the constant pool (depends on class names)
+    currentCpLength = constantPool.length(); // constant pool can be extended (never contracted) during loop
+    for (int i = 0; i < currentCpLength; i++) {
+      CpInfo cpInfo = getCpEntry(i);
+      if (cpInfo != null) {
+        // If this is an entry that references Descriptors and/or names, adjust them correspondingly
+        if (cpInfo instanceof MethodTypeCpInfo) {
+          MethodTypeCpInfo mt = (MethodTypeCpInfo) cpInfo;
+          Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(mt.getU2descriptorIndex());
+          String remapDesc = nm.mapDescriptor(descUtf.getString());
+          mt.setU2descriptorIndex(constantPool.remapUtf8To(remapDesc, mt.getU2descriptorIndex()));
+        } else if (cpInfo instanceof RefCpInfo) {
+          // Get the unmodified class name
+          ClassCpInfo classInfo = (ClassCpInfo) getCpEntry(((RefCpInfo) cpInfo).getClassIndex());
+          Utf8CpInfo classUtf = (Utf8CpInfo) getCpEntry(classInfo.getNameIndex());
+          String className = classUtf.getString();
+
+          // Get the current N&T reference and its 'name' and 'descriptor' utf's
+          int ntIndex = ((RefCpInfo) cpInfo).getNameAndTypeIndex();
+
+          NameAndTypeCpInfo nameTypeInfo = (NameAndTypeCpInfo) getCpEntry(ntIndex);
+          Utf8CpInfo refUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getNameIndex());
+          Utf8CpInfo descUtf = (Utf8CpInfo) getCpEntry(nameTypeInfo.getDescriptorIndex());
+
+          // Get the remapped versions of 'name' and 'descriptor'
+          String remapRef;
+          if (cpInfo instanceof FieldrefCpInfo) {
+            remapRef = nm.mapField(className, refUtf.getString());
+
+            // check if this is a compiler generated field
+            // supporting the JDK1.2-or-later '.class' construct
+            if (refUtf.getString().startsWith("class$")) {
+              if (!replaceClassNameStrings) {
+                String internalClassName = refUtf.getString().substring(6);
+                String realClassName = internalClassName.replace('$', '.');
+                internalClassName = internalClassName.replace('$', '/');
+                String map = nm.mapClass(internalClassName);
+                if (map != null && !internalClassName.equals(map)) {
+                  String warning = realClassName +
+                                   " shouldn't be obfuscated: it is most likely referenced as " + realClassName + ".class from " +
+                                   Conversion.toJavaClass(thisClassName);
+                  Logger.getInstance().warning(warning);
+                  log.println("<!-- WARNING: " + warning + " -->");
+                }
               }
             }
-            final String remapNames = sb.toString();
-            final int remapNamesIndex = constantPool.addUtf8Entry(remapNames);
-            final StringCpInfo remapNamesInfo = new StringCpInfo();
-            remapNamesInfo.setStringIndex(remapNamesIndex);
-            final int remapNamesInfoIndex = constantPool.addEntry(remapNamesInfo);
-            bm.getBootstrapArguments()[1] = remapNamesInfoIndex;
+          } else {
+            remapRef = nm.mapMethod(className, refUtf.getString(), descUtf.getString());
           }
-        }
-
-        // Remap all field/method names and descriptors in the constant pool (depends on class names)
-        currentCpLength = constantPool.length(); // constant pool can be extended (never contracted) during loop
-        for (int i = 0; i < currentCpLength; i++)
-        {
-            CpInfo cpInfo = getCpEntry(i);
-            if (cpInfo != null)
-            {
-              // If this is an entry that references Descriptors and/or names, adjust them correspondingly
-                if (cpInfo instanceof MethodTypeCpInfo){
-                  MethodTypeCpInfo mt = (MethodTypeCpInfo) cpInfo;
-                  Utf8CpInfo descUtf = (Utf8CpInfo)getCpEntry(mt.getU2descriptorIndex());
-                  String remapDesc = nm.mapDescriptor(descUtf.getString());
-                  mt.setU2descriptorIndex(constantPool.remapUtf8To(remapDesc, mt.getU2descriptorIndex()));
-                } else
-                if (cpInfo instanceof RefCpInfo)
-                {
-                    // Get the unmodified class name
-                    ClassCpInfo classInfo = (ClassCpInfo)getCpEntry(((RefCpInfo)cpInfo).getClassIndex());
-                    Utf8CpInfo classUtf = (Utf8CpInfo)getCpEntry(classInfo.getNameIndex());
-                    String className = classUtf.getString();
-
-                    // Get the current N&T reference and its 'name' and 'descriptor' utf's
-                    int ntIndex = ((RefCpInfo)cpInfo).getNameAndTypeIndex();
-
-                    NameAndTypeCpInfo nameTypeInfo = (NameAndTypeCpInfo)getCpEntry(ntIndex);
-                    Utf8CpInfo refUtf = (Utf8CpInfo)getCpEntry(nameTypeInfo.getNameIndex());
-                    Utf8CpInfo descUtf = (Utf8CpInfo)getCpEntry(nameTypeInfo.getDescriptorIndex());
-
-                    // Get the remapped versions of 'name' and 'descriptor'
-                    String remapRef;
-                    if (cpInfo instanceof FieldrefCpInfo)
-                    {
-                        remapRef = nm.mapField(className, refUtf.getString());
-
-                        // check if this is a compiler generated field
-                        // supporting the JDK1.2-or-later '.class' construct
-                        if (refUtf.getString().startsWith("class$"))
-                        {
-                          if (!replaceClassNameStrings){
-                            String internalClassName = refUtf.getString().substring(6);
-                            String realClassName = internalClassName.replace('$', '.');
-                            internalClassName = internalClassName.replace('$','/');
-                            String map = nm.mapClass(internalClassName);
-                            if (map != null && !internalClassName.equals(map)){
-                              String warning = realClassName +
-                                          " shouldn't be obfuscated: it is most likely referenced as " + realClassName + ".class from " +
-                                          Conversion.toJavaClass(thisClassName);
-                              Logger.getInstance().warning(warning);
-                              log.println("<!-- WARNING: " + warning + " -->");
-                            }
-                          }
-                        }
-                    }
-                    else
-                    {
-                      remapRef = nm.mapMethod(className, refUtf.getString(), descUtf.getString());
-                    }
-                    String remapDesc = nm.mapDescriptor(descUtf.getString());
-                    ((RefCpInfo)cpInfo).setNameAndTypeIndex(remapNT(refUtf, remapRef, descUtf, remapDesc, nameTypeInfo, ((RefCpInfo)cpInfo).getNameAndTypeIndex()));
-                }
-            }
-        }
-
-        // Finally, remap all class references to Utf
-        for (int i = 0; i < constantPool.length(); i++)
-        {
-            CpInfo cpInfo = getCpEntry(i);
-            if (cpInfo != null)
-            {
-                // If this is CONSTANT_Class, remap the class-name Utf8 entry
-                if (cpInfo instanceof ClassCpInfo)
-                {
-                    ClassCpInfo classInfo = (ClassCpInfo)cpInfo;
-                    Utf8CpInfo utf = (Utf8CpInfo)getCpEntry(classInfo.getNameIndex());
-                    String remapClass = nm.mapClass(utf.getString());
-                    int remapIndex = constantPool.remapUtf8To(remapClass, classInfo.getNameIndex());
-                    classInfo.setNameIndex(remapIndex);
-                } else if (cpInfo instanceof PackageCpInfo) {
-                    final PackageCpInfo info = (PackageCpInfo) cpInfo;
-                    final int pnIdx = info.getNameIndex();
-                    final CpInfo pnInfo = getCpEntry(pnIdx);
-                    if (pnInfo instanceof Utf8CpInfo) {
-                        final String oldName = ((Utf8CpInfo) pnInfo).getString();
-                        final String newName = nm.mapPackage(oldName);
-                        info.setNameIndex(constantPool.remapUtf8To(newName, pnIdx));
-                    }
-                }
-            }
-        }
-    }
-
-    private BootstrapMethodsAttrInfo getBootstrapMethodAttribute() {
-      for (int i = 0; i < attributes.length; i++) {
-        AttrInfo attribute = attributes[i];
-        if (attribute instanceof BootstrapMethodsAttrInfo) {
-          return (BootstrapMethodsAttrInfo) attribute;
-        }
-      }
-      throw new RuntimeException("No BootstrapMethod attribute in class file");
-    }
-
-    private int getType(BootstrapMethod method) {
-      final String sig = getBootstrapMethodSignature(method);
-      if ("java/lang/invoke/StringConcatFactory#makeConcat(...)".equals(sig)) {
-        return BM_TYPE_SCF;
-      } else if ("java/lang/invoke/StringConcatFactory#makeConcatWithConstants(...)".equals(sig)) {
-        return BM_TYPE_SCF;
-      } else if ("java/lang/invoke/LambdaMetafactory#metafactory(...)".equals(sig)) {
-        return BM_TYPE_LMF;
-      } else if ("java/lang/invoke/LambdaMetafactory#altMetafactory(...)".equals(sig)) {
-        return BM_TYPE_LMF;
-      } else if ("java/lang/runtime/ObjectMethods#bootstrap(...)".equals(sig)) {
-        return BM_TYPE_OM;
-      } else {
-        return BM_TYPE_UNKNOWN;
-      }
-    }
-
-    private BootstrapMethod getBootstrapMethod(InvokeDynamicCpInfo info) {
-      BootstrapMethodsAttrInfo bmInfo = getBootstrapMethodAttribute();
-      return bmInfo.getBootstrapMethods()[info.getBootstrapMethodAttrIndex()];
-    }
-
-    private String getBootstrapMethodSignature(BootstrapMethod method) {
-      final int mhIdx = method.getBootstrapMethodRef();
-      final MethodHandleCpInfo mhInfo = (MethodHandleCpInfo) getCpEntry(mhIdx);
-      final RefCpInfo mrInfo = (RefCpInfo) getCpEntry(mhInfo.getReferenceIndex());
-      final ClassCpInfo cpInfo = (ClassCpInfo) getCpEntry(mrInfo.getClassIndex());
-      final String className = getUtf8(cpInfo.getNameIndex());
-      final NameAndTypeCpInfo ntInfo = (NameAndTypeCpInfo) getCpEntry(mrInfo.getNameAndTypeIndex());
-      final String memberName = getUtf8(ntInfo.getNameIndex());
-      return className + '#' + memberName + getReferenceKindSuffix(mhInfo.getReferenceKind());
-    }
-
-    private static String getReferenceKindSuffix(int referenceKind) {
-      switch (referenceKind) {
-        case REF_getField:
-        case REF_getStatic:
-        case REF_putField:
-        case REF_putStatic:
-          return "";
-
-        case REF_invokeVirtual:
-        case REF_invokeStatic:
-        case REF_invokeSpecial:
-        case REF_newInvokeSpecial:
-        case REF_invokeInterface:
-          return "(...)";
-
-        default:
-          throw new IllegalArgumentException("Invalid reference kind: " + referenceKind);
-      }
-    }
-
-    private void remapAnnotationDefault(AnnotationDefaultAttrInfo annotationDefault, NameMapper nm){
-      remapElementValue(annotationDefault.elementValue, nm);
-    }
-
-    private void remapAnnotations(RuntimeVisibleAnnotationsAttrInfo annotation, NameMapper nm){
-      remapAnnotationInfoImpl(annotation.getAnnotations(), nm);
-    }
-
-    private void remapParameterAnnotations(RuntimeVisibleParameterAnnotationsAttrInfo annotation, NameMapper nm){
-      final ParameterAnnotationInfo[] annotations = annotation.getParameterAnnotations();
-      if (annotations != null){
-        for (int i = 0; i < annotations.length; i++){
-          final ParameterAnnotationInfo info = annotations[i];
-          remapAnnotationInfoImpl(info.getAnnotations(), nm);
+          String remapDesc = nm.mapDescriptor(descUtf.getString());
+          ((RefCpInfo) cpInfo).setNameAndTypeIndex(remapNT(refUtf, remapRef, descUtf, remapDesc, nameTypeInfo, ((RefCpInfo) cpInfo).getNameAndTypeIndex()));
         }
       }
     }
 
-    private void remapTypeAnnotations(RuntimeVisibleTypeAnnotationsAttrInfo annotation, NameMapper nm) {
-      remapAnnotationInfoImpl(annotation.getAnnotations(), nm);
-    }
-
-    private void remapAnnotationInfoImpl(AnnotationInfo[] a, NameMapper nm) {
-      if (a != null) {
-        for (int j = 0; j < a.length; j++) {
-          remapAnnotation(a[j], nm);
-        }
-      }
-    }
-
-    private void remapAnnotation(AnnotationInfo annotation, NameMapper nm){
-      CpInfo info = getCpEntry(annotation.u2typeIndex);
-      if (info instanceof Utf8CpInfo){
-        Utf8CpInfo utf = (Utf8CpInfo) info;
-        String s = utf.getString();
-        if (s.length() > 2 && s.charAt(0) == 'L' && s.charAt(s.length() - 1) == ';'){
-          String fqn = s.substring(1, s.length() - 1);
-          String newFqn = nm.mapClass(fqn);
-          if (!fqn.equals(newFqn)){
-            annotation.u2typeIndex = constantPool.remapUtf8To('L' + newFqn + ';', annotation.u2typeIndex);
-          }
-          final ElementValuePairInfo[] evp = annotation.getElementValuePairs();
-          if (evp != null){
-            for (int i = 0; i < evp.length; i++){
-              final ElementValuePairInfo elementValuePair = evp[i];
-              utf = (Utf8CpInfo) getCpEntry(elementValuePair.u2ElementNameIndex);
-              String remapName = nm.mapAnnotationField(fqn, utf.getString());
-              if (!remapName.equals(utf.getString())){
-                elementValuePair.u2ElementNameIndex = constantPool.remapUtf8To(remapName, elementValuePair.u2ElementNameIndex);
-              }
-              final ElementValueInfo elementValue = elementValuePair.elementValue;
-              remapElementValue(elementValue, nm);
-            }
+    // Finally, remap all class references to Utf
+    for (int i = 0; i < constantPool.length(); i++) {
+      CpInfo cpInfo = getCpEntry(i);
+      if (cpInfo != null) {
+        // If this is CONSTANT_Class, remap the class-name Utf8 entry
+        if (cpInfo instanceof ClassCpInfo) {
+          ClassCpInfo classInfo = (ClassCpInfo) cpInfo;
+          Utf8CpInfo utf = (Utf8CpInfo) getCpEntry(classInfo.getNameIndex());
+          String remapClass = nm.mapClass(utf.getString());
+          int remapIndex = constantPool.remapUtf8To(remapClass, classInfo.getNameIndex());
+          classInfo.setNameIndex(remapIndex);
+        } else if (cpInfo instanceof PackageCpInfo) {
+          final PackageCpInfo info = (PackageCpInfo) cpInfo;
+          final int pnIdx = info.getNameIndex();
+          final CpInfo pnInfo = getCpEntry(pnIdx);
+          if (pnInfo instanceof Utf8CpInfo) {
+            final String oldName = ((Utf8CpInfo) pnInfo).getString();
+            final String newName = nm.mapPackage(oldName);
+            info.setNameIndex(constantPool.remapUtf8To(newName, pnIdx));
           }
         }
       }
     }
+  }
 
-    private void remapElementValue(ElementValueInfo elementValue, NameMapper nm){
-      switch (elementValue.u1Tag)
-      {
-        case 'B':
-        case 'C':
-        case 'D':
-        case 'F':
-        case 'I':
-        case 'J':
-        case 'S':
-        case 'Z':
-        case 's':
-          // do nothing, this is a constant
-          break;
-        case 'e':
+  private BootstrapMethodsAttrInfo getBootstrapMethodAttribute() {
+    for (int i = 0; i < attributes.length; i++) {
+      AttrInfo attribute = attributes[i];
+      if (attribute instanceof BootstrapMethodsAttrInfo) {
+        return (BootstrapMethodsAttrInfo) attribute;
+      }
+    }
+    throw new RuntimeException("No BootstrapMethod attribute in class file");
+  }
+
+  private int getType( BootstrapMethod method ) {
+    final String sig = getBootstrapMethodSignature(method);
+    if ("java/lang/invoke/StringConcatFactory#makeConcat(...)".equals(sig)) {
+      return BM_TYPE_SCF;
+    } else if ("java/lang/invoke/StringConcatFactory#makeConcatWithConstants(...)".equals(sig)) {
+      return BM_TYPE_SCF;
+    } else if ("java/lang/invoke/LambdaMetafactory#metafactory(...)".equals(sig)) {
+      return BM_TYPE_LMF;
+    } else if ("java/lang/invoke/LambdaMetafactory#altMetafactory(...)".equals(sig)) {
+      return BM_TYPE_LMF;
+    } else if ("java/lang/runtime/ObjectMethods#bootstrap(...)".equals(sig)) {
+      return BM_TYPE_OM;
+    } else {
+      return BM_TYPE_UNKNOWN;
+    }
+  }
+
+  private BootstrapMethod getBootstrapMethod( InvokeDynamicCpInfo info ) {
+    BootstrapMethodsAttrInfo bmInfo = getBootstrapMethodAttribute();
+    return bmInfo.getBootstrapMethods()[info.getBootstrapMethodAttrIndex()];
+  }
+
+  private String getBootstrapMethodSignature( BootstrapMethod method ) {
+    final int mhIdx = method.getBootstrapMethodRef();
+    final MethodHandleCpInfo mhInfo = (MethodHandleCpInfo) getCpEntry(mhIdx);
+    final RefCpInfo mrInfo = (RefCpInfo) getCpEntry(mhInfo.getReferenceIndex());
+    final ClassCpInfo cpInfo = (ClassCpInfo) getCpEntry(mrInfo.getClassIndex());
+    final String className = getUtf8(cpInfo.getNameIndex());
+    final NameAndTypeCpInfo ntInfo = (NameAndTypeCpInfo) getCpEntry(mrInfo.getNameAndTypeIndex());
+    final String memberName = getUtf8(ntInfo.getNameIndex());
+    return className + '#' + memberName + getReferenceKindSuffix(mhInfo.getReferenceKind());
+  }
+
+  private static String getReferenceKindSuffix( int referenceKind ) {
+    switch (referenceKind) {
+      case REF_getField:
+      case REF_getStatic:
+      case REF_putField:
+      case REF_putStatic:
+        return "";
+
+      case REF_invokeVirtual:
+      case REF_invokeStatic:
+      case REF_invokeSpecial:
+      case REF_newInvokeSpecial:
+      case REF_invokeInterface:
+        return "(...)";
+
+      default:
+        throw new IllegalArgumentException("Invalid reference kind: " + referenceKind);
+    }
+  }
+
+  private void remapAnnotationDefault( AnnotationDefaultAttrInfo annotationDefault, NameMapper nm ) {
+    remapElementValue(annotationDefault.elementValue, nm);
+  }
+
+  private void remapAnnotations( RuntimeVisibleAnnotationsAttrInfo annotation, NameMapper nm ) {
+    remapAnnotationInfoImpl(annotation.getAnnotations(), nm);
+  }
+
+  private void remapParameterAnnotations( RuntimeVisibleParameterAnnotationsAttrInfo annotation, NameMapper nm ) {
+    final ParameterAnnotationInfo[] annotations = annotation.getParameterAnnotations();
+    if (annotations != null) {
+      for (int i = 0; i < annotations.length; i++) {
+        final ParameterAnnotationInfo info = annotations[i];
+        remapAnnotationInfoImpl(info.getAnnotations(), nm);
+      }
+    }
+  }
+
+  private void remapTypeAnnotations( RuntimeVisibleTypeAnnotationsAttrInfo annotation, NameMapper nm ) {
+    remapAnnotationInfoImpl(annotation.getAnnotations(), nm);
+  }
+
+  private void remapAnnotationInfoImpl( AnnotationInfo[] a, NameMapper nm ) {
+    if (a != null) {
+      for (int j = 0; j < a.length; j++) {
+        remapAnnotation(a[j], nm);
+      }
+    }
+  }
+
+  private void remapAnnotation( AnnotationInfo annotation, NameMapper nm ) {
+    CpInfo info = getCpEntry(annotation.u2typeIndex);
+    if (info instanceof Utf8CpInfo) {
+      Utf8CpInfo utf = (Utf8CpInfo) info;
+      String s = utf.getString();
+      if (s.length() > 2 && s.charAt(0) == 'L' && s.charAt(s.length() - 1) == ';') {
+        String fqn = s.substring(1, s.length() - 1);
+        String newFqn = nm.mapClass(fqn);
+        if (!fqn.equals(newFqn)) {
+          annotation.u2typeIndex = constantPool.remapUtf8To('L' + newFqn + ';', annotation.u2typeIndex);
+        }
+        final ElementValuePairInfo[] evp = annotation.getElementValuePairs();
+        if (evp != null) {
+          for (int i = 0; i < evp.length; i++) {
+            final ElementValuePairInfo elementValuePair = evp[i];
+            utf = (Utf8CpInfo) getCpEntry(elementValuePair.u2ElementNameIndex);
+            String remapName = nm.mapAnnotationField(fqn, utf.getString());
+            if (!remapName.equals(utf.getString())) {
+              elementValuePair.u2ElementNameIndex = constantPool.remapUtf8To(remapName, elementValuePair.u2ElementNameIndex);
+            }
+            final ElementValueInfo elementValue = elementValuePair.elementValue;
+            remapElementValue(elementValue, nm);
+          }
+        }
+      }
+    }
+  }
+
+  private void remapElementValue( ElementValueInfo elementValue, NameMapper nm ) {
+    switch (elementValue.u1Tag) {
+      case 'B':
+      case 'C':
+      case 'D':
+      case 'F':
+      case 'I':
+      case 'J':
+      case 'S':
+      case 'Z':
+      case 's':
+        // do nothing, this is a constant
+        break;
+      case 'e':
         // remap the type...
-        {
-          Utf8CpInfo utf = (Utf8CpInfo) getCpEntry(elementValue.u2typeNameIndex);
-          String name = utf.getString();
-          String remapName = nm.mapDescriptor(name);
-          elementValue.u2typeNameIndex = constantPool.remapUtf8To(remapName, elementValue.u2typeNameIndex);
-        }
-        // leave the constant value in u2constNameIndex
-        break;
-        case 'c':
-        {
-          Utf8CpInfo utf = (Utf8CpInfo) getCpEntry(elementValue.u2cpIndex);
-          String name = utf.getString();
-          String remapName = nm.mapDescriptor(name);
-          elementValue.u2cpIndex = constantPool.remapUtf8To(remapName, elementValue.u2cpIndex);
-        }
-        break;
-        case '@':
-          remapAnnotation(elementValue.nestedAnnotation, nm);
-          break;
-        case '[':
-          for (int j = 0; j < elementValue.arrayValues.length; j++)
-          {
-            final ElementValueInfo evi = elementValue.arrayValues[j];
-            remapElementValue(evi, nm);
-          }
-          break;
-        default:
-          throw new RuntimeException("Unknown type tag in annotation!");
-      }
-    }
-
-    private void remapSignature(NameMapper nm, SignatureAttrInfo signature){
-      CpInfo cpInfo = getCpEntry(signature.getSignatureIndex());
-      if (cpInfo instanceof Utf8CpInfo){
-        Utf8CpInfo utf = (Utf8CpInfo) cpInfo;
-        String sig = utf.getString();
-        String remapSignature = nm.mapSignature(sig);
-        if (!sig.equals(remapSignature)){
-          int remapIndex = constantPool.remapUtf8To(remapSignature, signature.getSignatureIndex());
-          signature.setSignatureIndex(remapIndex);
-        }
-      }
-    }
-
-    private int remapNT(Utf8CpInfo refUtf, String remapRef, Utf8CpInfo descUtf, String remapDesc, NameAndTypeCpInfo nameTypeInfo, int nameAndTypeIndex){
-      // If a remap is required, make a new N&T (increment ref count on 'name' and
-      // 'descriptor', decrement original N&T's ref count, set new N&T ref count to 1),
-      // remap new N&T's utf's
-      if (!remapRef.equals(refUtf.getString()) || !remapDesc.equals(descUtf.getString()))
       {
-        // Get the new N&T guy
-        NameAndTypeCpInfo newNameTypeInfo;
-        if (nameTypeInfo.getRefCount() == 1)
-        {
-          newNameTypeInfo = nameTypeInfo;
-        }
-        else
-        {
-          // Create the new N&T info
-          newNameTypeInfo = (NameAndTypeCpInfo)nameTypeInfo.clone();
-
-          // Adjust its reference counts of its utf's
-          ((CpInfo)getCpEntry(newNameTypeInfo.getNameIndex())).incRefCount();
-          ((CpInfo)getCpEntry(newNameTypeInfo.getDescriptorIndex())).incRefCount();
-
-          // Append it to the Constant Pool, and
-          // point the RefCpInfo entry to the new N&T data
-          nameAndTypeIndex = constantPool.addEntry(newNameTypeInfo);
-
-          // Adjust reference counts from RefCpInfo
-          newNameTypeInfo.incRefCount();
-          nameTypeInfo.decRefCount();
-        }
-
-        // Remap the 'name' and 'descriptor' utf's in N&T
-        newNameTypeInfo.setNameIndex(constantPool.remapUtf8To(remapRef, newNameTypeInfo.getNameIndex()));
-        newNameTypeInfo.setDescriptorIndex(constantPool.remapUtf8To(remapDesc, newNameTypeInfo.getDescriptorIndex()));
+        Utf8CpInfo utf = (Utf8CpInfo) getCpEntry(elementValue.u2typeNameIndex);
+        String name = utf.getString();
+        String remapName = nm.mapDescriptor(name);
+        elementValue.u2typeNameIndex = constantPool.remapUtf8To(remapName, elementValue.u2typeNameIndex);
       }
-      return nameAndTypeIndex;
+      // leave the constant value in u2constNameIndex
+      break;
+      case 'c': {
+        Utf8CpInfo utf = (Utf8CpInfo) getCpEntry(elementValue.u2cpIndex);
+        String name = utf.getString();
+        String remapName = nm.mapDescriptor(name);
+        elementValue.u2cpIndex = constantPool.remapUtf8To(remapName, elementValue.u2cpIndex);
+      }
+      break;
+      case '@':
+        remapAnnotation(elementValue.nestedAnnotation, nm);
+        break;
+      case '[':
+        for (int j = 0; j < elementValue.arrayValues.length; j++) {
+          final ElementValueInfo evi = elementValue.arrayValues[j];
+          remapElementValue(evi, nm);
+        }
+        break;
+      default:
+        throw new RuntimeException("Unknown type tag in annotation!");
     }
+  }
 
-    /**
-     * goes through the constantpool, identifies classnamestrings and replaces
-     * them appropriately if necessary
-     */
-    private void replaceConstantPoolStrings(ClassTree ct){
-      for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements();){
-        CpInfo cpi = (CpInfo) enumeration.nextElement();
-        if (cpi instanceof Utf8CpInfo){
-          Utf8CpInfo ui = (Utf8CpInfo) cpi;
-          String s = ui.getString();
-          boolean jikes = false;
-          if (s.length()>5 && s.startsWith("[L") && s.endsWith(";")){
-            s = s.substring(2, s.length()-1);
-            jikes = true;
-          }
-          if (s.length()>2 && Character.isJavaIdentifierPart(s.charAt(s.length()-1)) &&
-            s.indexOf(' ')<0 && s.indexOf('.')>0){
-            Cl cl = ct.findClassForName(s);
-            if (cl != null){
-              if (!cl.getFullInName().equals(cl.getFullOutName())){
-                if (jikes){
-                  ui.setString("[L"+cl.getFullOutName().replace('/','.')+";");
-                } else {
-                  ui.setString(cl.getFullOutName().replace('/','.'));
-                }
+  private void remapSignature( NameMapper nm, SignatureAttrInfo signature ) {
+    CpInfo cpInfo = getCpEntry(signature.getSignatureIndex());
+    if (cpInfo instanceof Utf8CpInfo) {
+      Utf8CpInfo utf = (Utf8CpInfo) cpInfo;
+      String sig = utf.getString();
+      String remapSignature = nm.mapSignature(sig);
+      if (!sig.equals(remapSignature)) {
+        int remapIndex = constantPool.remapUtf8To(remapSignature, signature.getSignatureIndex());
+        signature.setSignatureIndex(remapIndex);
+      }
+    }
+  }
+
+  private int remapNT( Utf8CpInfo refUtf, String remapRef, Utf8CpInfo descUtf, String remapDesc, NameAndTypeCpInfo nameTypeInfo, int nameAndTypeIndex ) {
+    // If a remap is required, make a new N&T (increment ref count on 'name' and
+    // 'descriptor', decrement original N&T's ref count, set new N&T ref count to 1),
+    // remap new N&T's utf's
+    if (!remapRef.equals(refUtf.getString()) || !remapDesc.equals(descUtf.getString())) {
+      // Get the new N&T guy
+      NameAndTypeCpInfo newNameTypeInfo;
+      if (nameTypeInfo.getRefCount() == 1) {
+        newNameTypeInfo = nameTypeInfo;
+      } else {
+        // Create the new N&T info
+        newNameTypeInfo = (NameAndTypeCpInfo) nameTypeInfo.clone();
+
+        // Adjust its reference counts of its utf's
+        ((CpInfo) getCpEntry(newNameTypeInfo.getNameIndex())).incRefCount();
+        ((CpInfo) getCpEntry(newNameTypeInfo.getDescriptorIndex())).incRefCount();
+
+        // Append it to the Constant Pool, and
+        // point the RefCpInfo entry to the new N&T data
+        nameAndTypeIndex = constantPool.addEntry(newNameTypeInfo);
+
+        // Adjust reference counts from RefCpInfo
+        newNameTypeInfo.incRefCount();
+        nameTypeInfo.decRefCount();
+      }
+
+      // Remap the 'name' and 'descriptor' utf's in N&T
+      newNameTypeInfo.setNameIndex(constantPool.remapUtf8To(remapRef, newNameTypeInfo.getNameIndex()));
+      newNameTypeInfo.setDescriptorIndex(constantPool.remapUtf8To(remapDesc, newNameTypeInfo.getDescriptorIndex()));
+    }
+    return nameAndTypeIndex;
+  }
+
+  /**
+   * goes through the constantpool, identifies classnamestrings and replaces
+   * them appropriately if necessary
+   */
+  private void replaceConstantPoolStrings( ClassTree ct ) {
+    for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); ) {
+      CpInfo cpi = (CpInfo) enumeration.nextElement();
+      if (cpi instanceof Utf8CpInfo) {
+        Utf8CpInfo ui = (Utf8CpInfo) cpi;
+        String s = ui.getString();
+        boolean jikes = false;
+        if (s.length() > 5 && s.startsWith("[L") && s.endsWith(";")) {
+          s = s.substring(2, s.length() - 1);
+          jikes = true;
+        }
+        if (s.length() > 2 && Character.isJavaIdentifierPart(s.charAt(s.length() - 1)) &&
+            s.indexOf(' ') < 0 && s.indexOf('.') > 0) {
+          Cl cl = ct.findClassForName(s);
+          if (cl != null) {
+            if (!cl.getFullInName().equals(cl.getFullOutName())) {
+              if (jikes) {
+                ui.setString("[L" + cl.getFullOutName().replace('/', '.') + ";");
+              } else {
+                ui.setString(cl.getFullOutName().replace('/', '.'));
               }
             }
           }
         }
       }
     }
+  }
 
-    /**
-     * Export the representation to a DataOutput stream.
-     *
-     * @param dout the dout
-     * @throws IOException the io exception
-     */
-    public void write(DataOutput dout) throws IOException
-    {
-        if (dout == null) throw new NullPointerException("No output stream was provided.");
-        dout.writeInt(u4magic);
-        dout.writeShort(u2minorVersion);
-        dout.writeShort(u2majorVersion);
-        dout.writeShort(constantPool.length() + (writeIdString ? 1 : 0));
-        for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); )
-        {
-            CpInfo cpInfo = (CpInfo)enumeration.nextElement();
-            if (cpInfo != null)
-            {
-                cpInfo.write(dout);
-            }
-        }
-        if (writeIdString) {
-            cpIdString.write(dout);
-        }
-        dout.writeShort(u2accessFlags);
-        dout.writeShort(u2thisClass);
-        dout.writeShort(u2superClass);
-        dout.writeShort(u2interfacesCount);
-        for (int i = 0; i < u2interfacesCount; i++)
-        {
-            dout.writeShort(u2interfaces[i]);
-        }
-        dout.writeShort(u2fieldsCount);
-        for (int i = 0; i < u2fieldsCount; i++)
-        {
-            fields[i].write(dout);
-        }
-        dout.writeShort(u2methodsCount);
-        for (int i = 0; i < u2methodsCount; i++)
-        {
-            methods[i].write(dout);
-        }
-        dout.writeShort(u2attributesCount);
-        for (int i = 0; i < u2attributesCount; i++)
-        {
-            attributes[i].write(dout);
-        }
+  /**
+   * Export the representation to a DataOutput stream.
+   *
+   * @param dout the dout
+   * @throws IOException the io exception
+   */
+  public void write( DataOutput dout ) throws IOException {
+    if (dout == null) {
+      throw new NullPointerException("No output stream was provided.");
     }
+    dout.writeInt(u4magic);
+    dout.writeShort(u2minorVersion);
+    dout.writeShort(u2majorVersion);
+    dout.writeShort(constantPool.length() + (writeIdString ? 1 : 0));
+    for (Enumeration enumeration = constantPool.elements(); enumeration.hasMoreElements(); ) {
+      CpInfo cpInfo = (CpInfo) enumeration.nextElement();
+      if (cpInfo != null) {
+        cpInfo.write(dout);
+      }
+    }
+    if (writeIdString) {
+      cpIdString.write(dout);
+    }
+    dout.writeShort(u2accessFlags);
+    dout.writeShort(u2thisClass);
+    dout.writeShort(u2superClass);
+    dout.writeShort(u2interfacesCount);
+    for (int i = 0; i < u2interfacesCount; i++) {
+      dout.writeShort(u2interfaces[i]);
+    }
+    dout.writeShort(u2fieldsCount);
+    for (int i = 0; i < u2fieldsCount; i++) {
+      fields[i].write(dout);
+    }
+    dout.writeShort(u2methodsCount);
+    for (int i = 0; i < u2methodsCount; i++) {
+      methods[i].write(dout);
+    }
+    dout.writeShort(u2attributesCount);
+    for (int i = 0; i < u2attributesCount; i++) {
+      attributes[i].write(dout);
+    }
+  }
 
-    /**
-     * Dump the content of the class file to the specified file (used for debugging).
-     *
-     * @param pw the pw
-     */
-    public void dump(PrintWriter pw)
-    {
-        pw.println("_____________________________________________________________________");
-        pw.println("CLASS: " + getName());
-        pw.println("Magic: " + Integer.toHexString(u4magic));
-        pw.println("Minor version: " + Integer.toHexString(u2minorVersion));
-        pw.println("Major version: " + Integer.toHexString(u2majorVersion));
-        pw.println();
-        pw.println("CP length: " + Integer.toHexString(constantPool.length()));
-        for (int i = 0; i < constantPool.length(); i++)
-        {
-            CpInfo cpInfo = (CpInfo)constantPool.getCpEntry(i);
-            if (cpInfo != null)
-            {
-                cpInfo.dump(pw, this, i);
-            }
-        }
-        pw.println("Access: " + Integer.toHexString(u2accessFlags));
-        pw.println("This class: " + getName());
-        pw.println("Superclass: " + getSuper());
-        pw.println("Interfaces count: " + Integer.toHexString(u2interfacesCount));
-        for (int i = 0; i < u2interfacesCount; i++)
-        {
-            CpInfo info = getCpEntry(u2interfaces[i]);
-            if (info == null)
-            {
-                pw.println("  Interface " + Integer.toHexString(i) + ": (null)");
-            }
-            else
-            {
-                pw.println("  Interface " + Integer.toHexString(i) + ": " + ((Utf8CpInfo)getCpEntry(((ClassCpInfo)info).getNameIndex())).getString());
-            }
-        }
-        pw.println("Fields count: " + Integer.toHexString(u2fieldsCount));
-        for (int i = 0; i < u2fieldsCount; i++)
-        {
-            ClassItemInfo info = fields[i];
-            if (info == null)
-            {
-                pw.println("  Field " + Integer.toHexString(i) + ": (null)");
-            }
-            else
-            {
-                pw.println("  Field " + Integer.toHexString(i) + ": " + ((Utf8CpInfo)getCpEntry(info.getNameIndex())).getString() + " " + ((Utf8CpInfo)getCpEntry(info.getDescriptorIndex())).getString());
-            }
-            pw.println("    Attrs count: " + Integer.toHexString(info.u2attributesCount));
-            for (int j = 0; j < info.u2attributesCount; j++)
-            {
-                pw.println(info.attributes[j]);
-            }
-        }
-        pw.println("Methods count: " + Integer.toHexString(u2methodsCount));
-        for (int i = 0; i < u2methodsCount; i++)
-        {
-            ClassItemInfo info = methods[i];
-            if (info == null)
-            {
-                pw.println("  Method " + Integer.toHexString(i) + ": (null)");
-            }
-            else
-            {
-                pw.println("  Method " + Integer.toHexString(i) + ": " + ((Utf8CpInfo)getCpEntry(info.getNameIndex())).getString() + " " + ((Utf8CpInfo)getCpEntry(info.getDescriptorIndex())).getString() + " " + Integer.toHexString(info.getAccessFlags()));
-            }
-            pw.println("    Attrs count: " + Integer.toHexString(info.u2attributesCount));
-            for (int j = 0; j < info.u2attributesCount; j++)
-            {
-                if (info.attributes[j] instanceof CodeAttrInfo){
-                  pw.println(info.attributes[j]);
-                  CodeAttrInfo cai = (CodeAttrInfo) info.attributes[j];
-                  for (int k = 0; k < cai.u2attributesCount; k++){
-                    pw.println(cai.attributes[k]);
-                  }
-                } else {
-                  pw.println(info.attributes[j]);
-                }
-            }
-        }
-        pw.println("Attrs count: " + Integer.toHexString(u2attributesCount));
-        for (int i = 0; i < u2attributesCount; i++)
-        {
-            pw.println(attributes[i]);
-        }
+  /**
+   * Dump the content of the class file to the specified file (used for debugging).
+   *
+   * @param pw the pw
+   */
+  public void dump( PrintWriter pw ) {
+    pw.println("_____________________________________________________________________");
+    pw.println("CLASS: " + getName());
+    pw.println("Magic: " + Integer.toHexString(u4magic));
+    pw.println("Minor version: " + Integer.toHexString(u2minorVersion));
+    pw.println("Major version: " + Integer.toHexString(u2majorVersion));
+    pw.println();
+    pw.println("CP length: " + Integer.toHexString(constantPool.length()));
+    for (int i = 0; i < constantPool.length(); i++) {
+      CpInfo cpInfo = (CpInfo) constantPool.getCpEntry(i);
+      if (cpInfo != null) {
+        cpInfo.dump(pw, this, i);
+      }
     }
+    pw.println("Access: " + Integer.toHexString(u2accessFlags));
+    pw.println("This class: " + getName());
+    pw.println("Superclass: " + getSuper());
+    pw.println("Interfaces count: " + Integer.toHexString(u2interfacesCount));
+    for (int i = 0; i < u2interfacesCount; i++) {
+      CpInfo info = getCpEntry(u2interfaces[i]);
+      if (info == null) {
+        pw.println("  Interface " + Integer.toHexString(i) + ": (null)");
+      } else {
+        pw.println("  Interface " + Integer.toHexString(i) + ": " + ((Utf8CpInfo) getCpEntry(((ClassCpInfo) info).getNameIndex())).getString());
+      }
+    }
+    pw.println("Fields count: " + Integer.toHexString(u2fieldsCount));
+    for (int i = 0; i < u2fieldsCount; i++) {
+      ClassItemInfo info = fields[i];
+      if (info == null) {
+        pw.println("  Field " + Integer.toHexString(i) + ": (null)");
+      } else {
+        pw.println("  Field " + Integer.toHexString(i) + ": " + ((Utf8CpInfo) getCpEntry(info.getNameIndex())).getString() + " " + ((Utf8CpInfo) getCpEntry(info.getDescriptorIndex())).getString());
+      }
+      pw.println("    Attrs count: " + Integer.toHexString(info.u2attributesCount));
+      for (int j = 0; j < info.u2attributesCount; j++) {
+        pw.println(info.attributes[j]);
+      }
+    }
+    pw.println("Methods count: " + Integer.toHexString(u2methodsCount));
+    for (int i = 0; i < u2methodsCount; i++) {
+      ClassItemInfo info = methods[i];
+      if (info == null) {
+        pw.println("  Method " + Integer.toHexString(i) + ": (null)");
+      } else {
+        pw.println("  Method " + Integer.toHexString(i) + ": " + ((Utf8CpInfo) getCpEntry(info.getNameIndex())).getString() + " " + ((Utf8CpInfo) getCpEntry(info.getDescriptorIndex())).getString() + " " + Integer.toHexString(info.getAccessFlags()));
+      }
+      pw.println("    Attrs count: " + Integer.toHexString(info.u2attributesCount));
+      for (int j = 0; j < info.u2attributesCount; j++) {
+        if (info.attributes[j] instanceof CodeAttrInfo) {
+          pw.println(info.attributes[j]);
+          CodeAttrInfo cai = (CodeAttrInfo) info.attributes[j];
+          for (int k = 0; k < cai.u2attributesCount; k++) {
+            pw.println(cai.attributes[k]);
+          }
+        } else {
+          pw.println(info.attributes[j]);
+        }
+      }
+    }
+    pw.println("Attrs count: " + Integer.toHexString(u2attributesCount));
+    for (int i = 0; i < u2attributesCount; i++) {
+      pw.println(attributes[i]);
+    }
+  }
 
   /**
    * Get attributes attr info [ ].

--- a/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
+++ b/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
@@ -1751,6 +1751,7 @@ public class ClassFile implements ClassConstants
     }
     return "";
   }
+
   public int getMajorVersion() {
     return u2majorVersion;
   }

--- a/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
+++ b/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
@@ -1751,12 +1751,4 @@ public class ClassFile implements ClassConstants
     }
     return "";
   }
-
-  public int getMajorVersion() {
-    return u2majorVersion;
-  }
-
-  public int getMinorVersion() {
-    return u2minorVersion;
-  }
 }

--- a/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
+++ b/src/main/java/com/yworks/yguard/obf/classfile/ClassFile.java
@@ -144,14 +144,15 @@ public class ClassFile implements ClassConstants
      * stream.
      *
      * @param din the din
+     * @param classVersionChecking check or not class file version (default true)
      * @return the class file
      * @throws IOException if class file is corrupt or incomplete
      */
-    public static ClassFile create(DataInput din, boolean multiReleaseClass) throws IOException
+    public static ClassFile create(DataInput din, boolean classVersionChecking) throws IOException
     {
         if (din == null) throw new NullPointerException("No input stream was provided.");
         ClassFile cf = new ClassFile();
-        cf.read(din, multiReleaseClass);
+        cf.read(din, classVersionChecking);
         return cf;
     }
 
@@ -338,7 +339,7 @@ public class ClassFile implements ClassConstants
     private ClassFile() {}
 
     // Import the class data to internal representation.
-    private void read(DataInput din, boolean multiReleaseClass) throws IOException
+    private void read(DataInput din, boolean classVersionChecking) throws IOException
     {
         // Read the class file
         u4magic = din.readInt();
@@ -350,9 +351,16 @@ public class ClassFile implements ClassConstants
         {
             throw new IOException("Invalid magic number in class file.");
         }
-        if (!multiReleaseClass && u2majorVersion > MAJOR_VERSION)
+        if (u2majorVersion > MAJOR_VERSION)
         {
-            throw new IOException("Incompatible version number for class file format: " + u2majorVersion+"."+u2minorVersion);
+            if (classVersionChecking)
+            {
+                throw new IOException("Incompatible version number for class file format: " + u2majorVersion+"."+u2minorVersion);
+            }
+            else
+            {
+                Logger.getInstance().warning("Incompatible version number for class file format: " + u2majorVersion+"."+u2minorVersion);
+            }
         }
 
 


### PR DESCRIPTION
In my experience there are many multi-release build for recent fast change of java language feature as like Project Room, Panama, Etc. I'm also ready multi-release jar use for Virtual thread in JDK 20. 

But when I try obfuscating with yGuard 4.0.0 it's failed due to supporting java format version. (<=17)
Surely, It's very helpful for ensure safety this kind of bytecode handling tool. But sometimes It's can be limitation of use to yGuard because java language feature change really fast.

So I suggest passing java class version check to classes at least in multi release path.